### PR TITLE
Mount in the agent binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Buildkite](https://buildkite.com/) plugin for running pipeline steps in [Docker](https://www.docker.com/) containers
 
+The `buildkite-agent` command line tool (and required environment variables) will also be mounted into the container, allowing you to use it for artifact download, etc.
+
 If you need more control, please see the [docker-compose Buildkite Plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin).
 
 The docker container has the host buildkite-agent binary mounted in to `/usr/bin/buildkite-agent` and the required environment variables set. 
@@ -33,11 +35,9 @@ The working directory where the pipeline’s code will be mounted to, and run fr
 
 Example: `/app`
 
-### `buildkite-agent-bin` (optional)
+### `mount-buildkite-agent` (optional)
 
-The path on the host for `buildkite-agent`. If not set, defaults to to `buildkite-agent` from the `$PATH`. 
-
-If set to `false` then no agent binary will be mounted and no env will be passed to the container. Make sure to pass this as a string, otherwise YAML will interpret it incorrectly.
+Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true`. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A [Buildkite](https://buildkite.com/) plugin for running pipeline steps in [Dock
 
 If you need more control, please see the [docker-compose Buildkite Plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin).
 
+The docker container has the host buildkite-agent binary mounted in to `/usr/bin/buildkite-agent` and the required environment variables set. 
+
 ## Example
 
 The following pipeline will run `yarn install` and `yarn run test` inside a Docker container using the [node:7 Docker image](https://hub.docker.com/_/node/):
@@ -30,6 +32,12 @@ Example: `node:7`
 The working directory where the pipeline’s code will be mounted to, and run from, inside the container.
 
 Example: `/app`
+
+### `buildkite-agent-bin` (optional)
+
+The path on the host for `buildkite-agent`. If not set, defaults to to `buildkite-agent` from the `$PATH`. 
+
+If set to `false` then no agent binary will be mounted and no env will be passed to the container. Make sure to pass this as a string, otherwise YAML will interpret it incorrectly.
 
 ## License
 

--- a/hooks/command
+++ b/hooks/command
@@ -5,20 +5,19 @@ set -euo pipefail
 args=(
   "-it"
   "--rm"
-  "-v" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR}"
+  "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR}"
   "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR}"
 )
 
-if [[ -z "${BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN:-}" ]] ; then
-  BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN=$(which buildkite-agent || echo "false")
-fi
 
-[[ "${BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN}" != "false" ]] && args+=(
-  "-e" "BUILDKITE_JOB_ID"
-  "-e" "BUILDKITE_BUILD_ID"
-  "-e" "BUILDKITE_AGENT_ACCESS_TOKEN"
-  "-v" "${BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN}:/usr/bin/buildkite-agent"
-)
+if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-true}" =~ (true|on|1) ]] ; then
+  args+=(
+    "--env" "BUILDKITE_JOB_ID"
+    "--env" "BUILDKITE_BUILD_ID"
+    "--env" "BUILDKITE_AGENT_ACCESS_TOKEN"
+    "--volume" "$(which buildkite-agent):/usr/bin/buildkite-agent"
+  )
+fi
 
 echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 docker run "${args[@]}" "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" bash -c "${BUILDKITE_COMMAND}"

--- a/hooks/command
+++ b/hooks/command
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ -n "${BUILDKITE_BIN:-}" ]] ; then
+if [[ -z "${BUILDKITE_BIN:-}" ]] ; then
   BUILDKITE_BIN=$(which buildkite-agent)
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -2,9 +2,14 @@
 
 set -euo pipefail
 
+if [[ -n "${BUILDKITE_BIN_PATH:-}" ]] ; then
+  BUILDKITE_BIN_PATH=$(which buildkite-agent)
+fi
+
 docker run \
   -it \
   --rm \
+  -v "$BUILDKITE_BIN_PATH:/usr/bin/buildkite-agent" \
   -v "$(pwd):${BUILDKITE_PLUGIN_DOCKER_WORKDIR}" \
   --workdir "${BUILDKITE_PLUGIN_DOCKER_WORKDIR}" \
   "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" \

--- a/hooks/command
+++ b/hooks/command
@@ -2,18 +2,23 @@
 
 set -euo pipefail
 
-if [[ -z "${BUILDKITE_BIN:-}" ]] ; then
-  BUILDKITE_BIN=$(which buildkite-agent)
+args=(
+  "-it"
+  "--rm"
+  "-v" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR}"
+  "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR}"
+)
+
+if [[ -z "${BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN:-}" ]] ; then
+  BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN=$(which buildkite-agent || echo "false")
 fi
 
-docker run \
-  -it \
-  --rm \
-  -e BUILDKITE_JOB_ID \
-  -e BUILDKITE_BUILD_ID \
-  -e BUILDKITE_AGENT_ACCESS_TOKEN \
-  -v "$BUILDKITE_BIN:/usr/bin/buildkite-agent" \
-  -v "$(pwd):${BUILDKITE_PLUGIN_DOCKER_WORKDIR}" \
-  --workdir "${BUILDKITE_PLUGIN_DOCKER_WORKDIR}" \
-  "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" \
-  bash -c "${BUILDKITE_COMMAND}"
+[[ "${BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN}" != "false" ]] && args+=(
+  "-e" "BUILDKITE_JOB_ID"
+  "-e" "BUILDKITE_BUILD_ID"
+  "-e" "BUILDKITE_AGENT_ACCESS_TOKEN"
+  "-v" "${BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN}:/usr/bin/buildkite-agent"
+)
+
+echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+docker run "${args[@]}" "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" bash -c "${BUILDKITE_COMMAND}"

--- a/hooks/command
+++ b/hooks/command
@@ -2,14 +2,17 @@
 
 set -euo pipefail
 
-if [[ -n "${BUILDKITE_BIN_PATH:-}" ]] ; then
-  BUILDKITE_BIN_PATH=$(which buildkite-agent)
+if [[ -n "${BUILDKITE_BIN:-}" ]] ; then
+  BUILDKITE_BIN=$(which buildkite-agent)
 fi
 
 docker run \
   -it \
   --rm \
-  -v "$BUILDKITE_BIN_PATH:/usr/bin/buildkite-agent" \
+  -e BUILDKITE_JOB_ID \
+  -e BUILDKITE_BUILD_ID \
+  -e BUILDKITE_AGENT_ACCESS_TOKEN \
+  -v "$BUILDKITE_BIN:/usr/bin/buildkite-agent" \
   -v "$(pwd):${BUILDKITE_PLUGIN_DOCKER_WORKDIR}" \
   --workdir "${BUILDKITE_PLUGIN_DOCKER_WORKDIR}" \
   "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" \

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-# export DOCKER_STUB_DEBUG=/dev/tty
+export DOCKER_STUB_DEBUG=/dev/tty
 # export WHICH_STUB_DEBUG=/dev/tty
 
 @test "Runs the command using docker" {
@@ -15,7 +15,7 @@ load '/usr/local/lib/bats/load.bash'
     "buildkite-agent : echo /buildkite-agent"
 
   stub docker \
-    "run -it --rm -v $PWD:/app --workdir /app -e BUILDKITE_JOB_ID  -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -c 'command1 \"a string\" && command2' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -c 'command1 \"a string\" && command2' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -32,11 +32,11 @@ load '/usr/local/lib/bats/load.bash'
 @test "Runs the command using docker with buildkite-agent-bin disabled" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_BUILDKITE_AGENT_BIN=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
-    "run -it --rm -v $PWD:/app --workdir /app image:tag bash -c 'pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,8 +3,8 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-export DOCKER_STUB_DEBUG=/dev/tty
-export WHICH_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
+# export WHICH_STUB_DEBUG=/dev/tty
 
 @test "Runs the command using docker" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
@@ -15,7 +15,7 @@ export WHICH_STUB_DEBUG=/dev/tty
     "buildkite-agent : echo /opt/llamas/buildkite-agent"
 
   stub docker \
-    "run -it --rm -v /opt/llamas/buildkite-agent:/usr/bin/buildkite-agent -v $PWD:/app --workdir /app image:tag bash -c 'command1 \"a string\" && command2' : echo ran command in docker"
+    "run -it --rm   -e BUILDKITE_JOB_ID  -e BUILDKITE_BUILD_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -v /opt/llamas/buildkite-agent:/usr/bin/buildkite-agent -v $PWD:/app --workdir /app image:tag bash -c 'command1 \"a string\" && command2' : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,15 +3,19 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-# export DOCKER_STUB_DEBUG=/dev/tty
+export DOCKER_STUB_DEBUG=/dev/tty
+export WHICH_STUB_DEBUG=/dev/tty
 
 @test "Runs the command using docker" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND="command1 \"a string\" && command2"
 
+  stub which \
+    "buildkite-agent : echo /opt/llamas/buildkite-agent"
+
   stub docker \
-    "run -it --rm -v $PWD:/app --workdir /app image:tag bash -c 'command1 \"a string\" && command2' : echo ran command in docker"
+    "run -it --rm -v /opt/llamas/buildkite-agent:/usr/bin/buildkite-agent -v $PWD:/app --workdir /app image:tag bash -c 'command1 \"a string\" && command2' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -19,6 +23,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
+  unstub which
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND


### PR DESCRIPTION
This mounts the buildkite-agent binary into the container from the host and provides the minimum env. 