### PR TITLE
Make workdir optional and set a sensible default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The name of the Docker image to use.
 
 Example: `node:7`
 
-### `workdir` (required)
+### `workdir`(optional)
 
-The working directory where the pipeline’s code will be mounted to, and run from, inside the container.
+The working directory where the pipeline’s code will be mounted to, and run from, inside the container. The default is `/workdir`.
 
 Example: `/app`
 

--- a/hooks/command
+++ b/hooks/command
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 if [[ -z "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] ; then
-  echo "Must set a workdir"
-  exit 1
+  BUILDKITE_PLUGIN_DOCKER_WORKDIR="/workdir"
 fi
 
 args=(


### PR DESCRIPTION
This patch makes workdir optional and adds a default.

In a docker pipeline build, the workdir is most of the time irrelevant as long as the command runs in the same path as the code.

Less required stuff, easier adoption :-)