### PR TITLE
Added possibility to mounts extra volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ steps:
           - MY_SPECIAL_VALUE=1
 ```
 
+You can pass in additional volume mounts. This is useful for docker-in-docker:
+
+```yml
+steps:
+  - command: docker build . -t image:tag
+    plugins:
+      docker#v1.0.0:
+        image: "docker:latest"
+        mounts:
+          - /var/run/docker.sock:/var/run/docker.sock
+```
+
 ## Configuration
 
 ### `image` (required)
@@ -52,9 +64,17 @@ Example: `/app`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true`. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
+### `mounts` (optional)
+
+Extra volume mounts to pass to the docker container, in an array of `SOURCE:TARGET` params
+
+Example: `/var/run/docker.sock:/var/run/docker.sock`
+
 ### `environment` (optional)
 
-Extra environment variables to pass to the docker container, in an array of KEY=VALUE params.
+Extra environment variables to pass to the docker container, in an array of `KEY=VALUE` params.
+
+Example: `MY_SPECIAL_VALUE=1`
 
 ## License
 

--- a/hooks/command
+++ b/hooks/command
@@ -31,5 +31,12 @@ while IFS='=' read -r name _ ; do
   fi
 done < <(env | sort)
 
+# Handle extra volumes
+while IFS='=' read -r name _ ; do
+  if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_MOUNTS_[0-9]+) ]] ; then
+    args+=( "--volume" "${!name}" )
+  fi
+done < <(env | sort)
+
 echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 docker run "${args[@]}" "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" bash -c "${BUILDKITE_COMMAND}"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -63,6 +63,30 @@ export DOCKER_STUB_DEBUG=/dev/tty
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 }
 
+@test "Runs command with volumes" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
+  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag bash -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
+}
+
 
 @test "Runs command with environment" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app


### PR DESCRIPTION
This patch adds the possibility to mounts extra volumes.

Once #6, #8 and #9 are merged, it should cover all docker primitives (people will no longer need to fork this plugin to make their stuff work, pretty much everything would be possible from the options). 

