### PR TITLE
Add back "bash -c" before commands

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -59,8 +59,4 @@ if [[ "${debug_mode:-off}" =~ (on) ]] ; then
     "${BUILDKITE_COMMAND}" >&2
 fi
 
-# The eval statements below are used to allow $BUILDKITE_COMMAND to be interpolated correctly
-# for complex quoted commands. The set -f ensures we don't expand globs in $BUILDKITE_COMMAND
-
-set -f
-eval "docker run \${args[*]} ${BUILDKITE_PLUGIN_DOCKER_IMAGE} ${BUILDKITE_COMMAND}"
+docker run "${args[@]}" "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" bash -c "${BUILDKITE_COMMAND}"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -15,7 +15,7 @@ load '/usr/local/lib/bats/load.bash'
     "buildkite-agent : echo /buildkite-agent"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag $BUILDKITE_COMMAND : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -c 'command1 \"a string\"' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -37,7 +37,7 @@ load '/usr/local/lib/bats/load.bash'
     "buildkite-agent : echo /buildkite-agent"
 
   stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag $BUILDKITE_COMMAND : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -c 'command1 \"a string\"' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -60,7 +60,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull image:tag : echo pulled latest image" \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -84,7 +84,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -104,10 +104,10 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
-  export BUILDKITE_COMMAND="bash -c 'echo hello world'"
+  export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag bash -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag bash -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -132,7 +132,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag echo hello world : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag bash -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -155,7 +155,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag echo hello world : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag bash -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -177,7 +177,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag echo hello world : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 


### PR DESCRIPTION
Turns out I broke backwards compatibility with 1.0.0 with the 1.1.0 release. I missed that we'd used `bash -c` as a command runner for all commands. This adds it back, and we will drop it shortly in a 2.0.0 release. 

Apologies folks!