### PR TITLE
Add support for connecting the container to a docker network

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ steps:
           - /var/run/docker.sock:/var/run/docker.sock
 ```
 
+You can specify a docker network to join. This will be created if it does not already exist:
+
+```yml
+steps:
+  - command: docker build . -t image:tag
+    plugins:
+      docker#v1.1.1:
+        image: "docker:latest"
+        network: "test-network"
+```
+
 ## Configuration
 
 ### `image` (required)
@@ -85,6 +96,12 @@ Example: `MY_SPECIAL_VALUE=1`
 Allows a user to be set, and override the USER entry in the Dockerfile. See https://docs.docker.com/engine/reference/run/#user for more details.
 
 Example: `root`
+
+### `network` (optional)
+
+Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details. 
+
+Example: `test-network`
 
 ### `debug` (optional)
 

--- a/hooks/command
+++ b/hooks/command
@@ -51,6 +51,18 @@ while IFS='=' read -r name _ ; do
   fi
 done < <(env | sort)
 
+# Parse network and create it if it don't exist. 
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}" ]] ; then
+  DOCKER_NETWORK_ID=$(docker network ls --quiet --filter "name=${BUILDKITE_PLUGIN_DOCKER_NETWORK}")
+  if [[ -z ${DOCKER_NETWORK_ID} ]] ; then
+    echo "creating network ${BUILDKITE_PLUGIN_DOCKER_NETWORK}"
+    docker network create ${BUILDKITE_PLUGIN_DOCKER_NETWORK}
+  else 
+    echo "docker network ${BUILDKITE_PLUGIN_DOCKER_NETWORK} already exists"
+  fi
+  args+=("--network" "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}")
+fi
+
 echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 
 if [[ "${debug_mode:-off}" =~ (on) ]] ; then

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -169,7 +169,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
-@test "Runs command with network" {
+@test "Runs command with network that doesn't exist" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -169,6 +169,33 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
+@test "Runs command with network" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
+  # export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "network create foo : creating network foo" \
+    "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag bash -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+  echo "status = ${status}"
+  echo "output = ${output}"
+
+  assert_success
+  assert_output --partial "creating network foo"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_NETWORK
+}
+
 @test "Runs with debug mode" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -174,16 +174,14 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
-  # export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "network create foo : creating network foo" \
+    "network ls --quiet --filter 'name=foo' : echo " \
+    "network create foo : echo creating network foo" \
     "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag bash -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
-  echo "status = ${status}"
-  echo "output = ${output}"
 
   assert_success
   assert_output --partial "creating network foo"
@@ -195,6 +193,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_NETWORK
 }
+
 
 @test "Runs with debug mode" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app


### PR DESCRIPTION
Enables connecting the docker container to the specified docker network. Will create the network if it does not exist. 

(See issue #13 for more info) 