### PR TITLE
Add 'srcdir' plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ The working directory where the pipeline’s code will be mounted to, and run fr
 
 Example: `/app`
 
+### `srcdir` (optional)
+
+The relative path to the source directory you wish to mount into the running container. The default is `./`.
+
+Example: `./components/my-source`
+
 ### `always-pull` (optional)
 
 Whether to always pull the latest image before running the command. Useful if the image has a `latest` tag. The default is false, the image will only get pulled if not present.
@@ -99,7 +105,7 @@ Example: `root`
 
 ### `network` (optional)
 
-Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details. 
+Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details.
 
 Example: `test-network`
 

--- a/hooks/command
+++ b/hooks/command
@@ -9,10 +9,12 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_DEBUG:-false}" =~ (true|on|1) ]] ; then
   set -x
 fi
 
+srcdir=$(realpath $PWD/${BUILDKITE_PLUGIN_DOCKER_SRCDIR:-./})
+
 args=(
   "-it"
   "--rm"
-  "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
+  "--volume" "$srcdir:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
   "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
 )
 
@@ -51,13 +53,13 @@ while IFS='=' read -r name _ ; do
   fi
 done < <(env | sort)
 
-# Parse network and create it if it don't exist. 
+# Parse network and create it if it don't exist.
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}" ]] ; then
   DOCKER_NETWORK_ID=$(docker network ls --quiet --filter "name=${BUILDKITE_PLUGIN_DOCKER_NETWORK}")
   if [[ -z ${DOCKER_NETWORK_ID} ]] ; then
     echo "creating network ${BUILDKITE_PLUGIN_DOCKER_NETWORK}"
     docker network create ${BUILDKITE_PLUGIN_DOCKER_NETWORK}
-  else 
+  else
     echo "docker network ${BUILDKITE_PLUGIN_DOCKER_NETWORK} already exists"
   fi
   args+=("--network" "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}")

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -11,6 +11,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND='command1 "a string"'
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub which \
     "buildkite-agent : echo /buildkite-agent"
 
@@ -24,6 +27,7 @@ load '/usr/local/lib/bats/load.bash'
 
   unstub docker
   unstub which
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
@@ -32,6 +36,9 @@ load '/usr/local/lib/bats/load.bash'
 @test "Run command without a workdir should not fail" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND="command1 \"a string\""
+
+  stub realpath \
+    "$PWD/./ : echo $PWD"
 
   stub which \
     "buildkite-agent : echo /buildkite-agent"
@@ -46,6 +53,7 @@ load '/usr/local/lib/bats/load.bash'
 
   unstub docker
   unstub which
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
@@ -58,6 +66,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub docker \
     "pull image:tag : echo pulled latest image" \
     "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'pwd' : echo ran command in docker"
@@ -69,6 +80,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
@@ -83,6 +95,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub docker \
     "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'pwd' : echo ran command in docker"
 
@@ -92,6 +107,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
@@ -106,6 +122,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub docker \
     "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag bash -c 'echo hello world; pwd' : echo ran command in docker"
 
@@ -115,6 +134,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
@@ -131,6 +151,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=ANOTHER_TAG=llamas
   export BUILDKITE_COMMAND="echo hello world"
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub docker \
     "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag bash -c 'echo hello world' : echo ran command in docker"
 
@@ -140,6 +163,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
@@ -154,6 +178,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_USER=foo
   export BUILDKITE_COMMAND="echo hello world"
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub docker \
     "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag bash -c 'echo hello world' : echo ran command in docker"
 
@@ -163,6 +190,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
@@ -202,6 +230,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
   export BUILDKITE_COMMAND="echo hello world"
 
+  stub realpath \
+    "$PWD/./ : echo $PWD"
+
   stub docker \
     "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -c 'echo hello world' : echo ran command in docker"
 
@@ -212,9 +243,40 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "$ docker run"
 
   unstub docker
+  unstub realpath
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_DEBUG
+  unset BUILDKITE_COMMAND
+}
+
+
+@test "Runs command with special src directory" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_SRCDIR=./dir
+  export BUILDKITE_COMMAND='command1 "a string"'
+
+  stub realpath \
+    "$PWD/./dir : echo $PWD/dir"
+
+  stub which \
+    "buildkite-agent : echo /buildkite-agent"
+
+  stub docker \
+    "run -it --rm --volume $PWD/dir:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -c 'command1 \"a string\"' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unstub which
+  unstub realpath
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_SRCDIR
   unset BUILDKITE_COMMAND
 }


### PR DESCRIPTION
This value allows you to specify which directory (relative to $PWD) you wish to mount as the `workdir` in your container. This is designed to be used with Docker Images that have hard-coded ENTRYPOINTs.

### Example
```
steps:
  - label: terraform
    commands:
      - fmt -check=true
      - validate -check-variables=false
    plugins:
     docker#v1.1.X:
        image: "hashicorp/terraform"
        srcdir: "./terraform"
```