### PR TITLE
Allow pwd mount to be skipped

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -16,7 +16,7 @@ args=(
 # Handle the mount-checkout-path option
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT_PATH:-true}" =~ (true|on|1) ]] ; then
   args+=(
-    "--volume" "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
+    "--volume" "${PWD}:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
     "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
   )
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -11,9 +11,15 @@ fi
 args=(
   "-it"
   "--rm"
-  "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
-  "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
 )
+
+# Handle the mount-checkout-path option
+if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT_PATH:-true}" =~ (true|on|1) ]] ; then
+  args+=(
+    "--volume" "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
+    "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
+  )
+fi
 
 # Support docker run --user
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USER:-}" ]] ; then


### PR DESCRIPTION
Kubernetes on Google Container OS doesn't like host mounts, so this adds a `mount-checkout-path` option so that this behaviour can be disabled. 