### PR TITLE
Support additional groups (--group-add)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Allows a user to be set, and override the USER entry in the Dockerfile. See http
 
 Example: `root`
 
+### `additional_groups` (optional)
+
+Additional groups to be added to the user in the container, in an array of group names (or ids). See https://docs.docker.com/engine/reference/run/#additional-groups for more details.
+
+Example: `docker`
+
 ### `network` (optional)
 
 Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details. 

--- a/hooks/command
+++ b/hooks/command
@@ -21,6 +21,13 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USER:-}" ]] ; then
   args+=("-u" "${BUILDKITE_PLUGIN_DOCKER_USER:-}")
 fi
 
+# Support docker run --group-add
+while IFS='=' read -r name _ ; do
+  if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_[0-9]+) ]] ; then
+    args+=( "--group-add" "${!name}" )
+  fi
+done < <(env | sort)
+
 # Handle the mount-buildkite-agent option
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-true}" =~ (true|on|1) ]] ; then
   args+=(

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -169,6 +169,30 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
+@test "Runs command with additional groups" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
+  export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag bash -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
+  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
+}
+
 @test "Runs command with network that doesn't exist" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag


### PR DESCRIPTION
This PR adds an `additional_groups` option to the plugin which takes an array of groups (either names or ids), and translates them to [`--group-add` options](https://docs.docker.com/engine/reference/run/#additional-groups) to pass to `docker run`.

I wanted to be able to do this because I'm trying to do some docker-in-docker stuff as an unprivileged user, so I need to be in the `docker` group. My config would then be something like

```yaml
docker#v1.1.1:
  image: "docker:latest"

  mounts:
    - /var/run/docker.sock:/var/run/docker.sock
    - # other mounts

  user: "501:502" # uid:gid of the user on the host, for access to the other mounts
  additional_groups:
    - 501 # gid of docker group on the host, for access to the docker socket
```