### PR TITLE
Improvements

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -17,8 +17,8 @@ args=(
 )
 
 # built-in support for the "USER_UID" and "USER_GID" environment variables, initialized to the BuildKite agent's user
-args+=( "--env" "USER_UID=$(id -u)" )
-args+=( "--env" "USER_GID=$(id -g)" )
+args+=( "--env" "SOURCE_UID=$(id -u)" )
+args+=( "--env" "SOURCE_GID=$(id -g)" )
 
 # add custom hosts to container's "/etc/hosts" by sending "--add host" arg to docker command
 if [[ -f "/etc/buildkite-agent/hosts" ]]; then
@@ -90,7 +90,7 @@ echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMA
 if [[ "${debug_mode:-off}" =~ (on) ]] ; then
   printf "$ docker run ${args[*]} %q  %q" \
     "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" \
-    "${BUILDKITE_COMMAND}" >&2
+    "${BUILDKITE_COMMAND}\n" >&2
 fi
 
-docker run "${args[@]}" "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" bash -c "${BUILDKITE_COMMAND}"
+bash -c "docker run \"${args[@]}\" \"${BUILDKITE_PLUGIN_DOCKER_IMAGE}\" ${BUILDKITE_COMMAND}"

--- a/hooks/command
+++ b/hooks/command
@@ -17,8 +17,8 @@ args=(
 )
 
 # built-in support for the "USER_UID" and "USER_GID" environment variables, initialized to the BuildKite agent's user
-args+=( "--env" "USER_UID=${UID}" )
-args+=( "--env" "USER_GID=${GID}" )
+args+=( "--env" "USER_UID=$(id -u)" )
+args+=( "--env" "USER_GID=$(id -g)" )
 
 # add custom hosts to container's "/etc/hosts" by sending "--add host" arg to docker command
 if [[ -f "/etc/buildkite-agent/hosts" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -16,6 +16,13 @@ args=(
   "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
 )
 
+# add custom hosts to container's "/etc/hosts" by sending "--add host" arg to docker command
+if [[ -f "/etc/buildkite-agent/hosts" ]]; then
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        args+=("--add-host" "${line}")
+    done < "/etc/buildkite-agent/hosts"
+fi
+
 # Support docker run --user
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USER:-}" ]] ; then
   args+=("-u" "${BUILDKITE_PLUGIN_DOCKER_USER:-}")

--- a/hooks/command
+++ b/hooks/command
@@ -16,6 +16,10 @@ args=(
   "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
 )
 
+# built-in support for the "USER_UID" and "USER_GID" environment variables, initialized to the BuildKite agent's user
+args+=( "--env" "USER_UID=${UID}" )
+args+=( "--env" "USER_GID=${GID}" )
+
 # add custom hosts to container's "/etc/hosts" by sending "--add host" arg to docker command
 if [[ -f "/etc/buildkite-agent/hosts" ]]; then
     while IFS='' read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
Several improvements:

- Pass `SOURCE_UID` and `SOURCE_GID` to container as environment variables.
- Fix debugging output.
- Use an alternative method of passing arguments to the Docker `run` command, which supports commands comprised of multiple tokens.
- Support loading custom hostnames to pass to the container from a `/etc/buildkite-agent/hosts` file (passed as `--add-host` argument to the `docker run` command)

We found these improvements to be useful in multiple occasions, specifically:
- the `SOURCE_UID` and `SOURCE_GID` parameters are useful for containers that need to persist some changes in files under the workdir, and ensure they can be read by the outer process (ie. the buildkite agent)
- the alternative method of running the container is meant to ensure that the `BUILDKITE_COMMAND` argument is provided to the `docker run ...` command as multiple arguments (parsed by `bash`) instead of just one string.