### PR TITLE
Add docker runtime support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Outputs the command to be run, and enables xtrace in the plugin
 
 Example: `true`
 
+### `runtime` (optional)
+
+Specify an explicit docker runtime. See https://docs.docker.com/engine/reference/commandline/run/#options for more details.
+
+Example: `nvidia`
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -74,6 +74,11 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}" ]] ; then
   args+=("--network" "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}")
 fi
 
+# Support docker run --runtime
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_RUNTIME:-}" ]] ; then
+  args+=("--runtime" "${BUILDKITE_PLUGIN_DOCKER_RUNTIME:-}")
+fi
+
 echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 
 if [[ "${debug_mode:-off}" =~ (on) ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,8 @@ configuration:
       type: string
     debug:
       type: boolean
+    runtime:
+      type: string
   required:
     - image
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -235,3 +235,26 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_DEBUG
   unset BUILDKITE_COMMAND
 }
+
+@test "Runs with custom runtime" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag bash -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
+  unset BUILDKITE_COMMAND
+}


### PR DESCRIPTION
Adds passthrough support for the `docker run` `--runtime` parameter, allowing pipeline-level specification of  the target docker runtime. This is primarily intended to provide support for [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) in contexts where the default docker runtime can not, or should not, be reconfigured, allowing the use of CUDA devices within pipeline steps. A minimal example configuration is given at [uw-ipd/buildkite-cuda](https://github.com/uw-ipd/buildkite-cuda). 

- [ ] Expand `--runtime` documentation.
- [ ] Provide tutorial for basic configuration of cuda-enabled docker-based buildkite agent?