### PR TITLE
Don't echo env vars

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -45,7 +45,7 @@ fi
 # Parse extra env vars and add them to the docker args
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_[0-9]+) ]] ; then
-    echo "parsed env[$name] = [${!name}]"
+    echo "parsed env[$name]"
     args+=( "--env" "${!name}" )
   fi
 done < <(env | sort)


### PR DESCRIPTION
We print the environment key values from the pipeline.yml to the build log. Should we do this always? Should we do it when `debug: true` is enabled (as it's done when it prints the args)