### PR TITLE
Remove set -x as its too noisy, and breaks headers

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -6,7 +6,6 @@ debug_mode='off'
 if [[ "${BUILDKITE_PLUGIN_DOCKER_DEBUG:-false}" =~ (true|on|1) ]] ; then
   echo "--- :hammer: Enabling debug mode"
   debug_mode='on'
-  set -x
 fi
 
 args=(


### PR DESCRIPTION
I spotted `set -x` in here. It might be a good idea to do without?