### PR TITLE
Detect if a shell is needed for command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Example: `docker`
 
 ### `network` (optional)
 
-Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details. 
+Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details.
 
 Example: `test-network`
 
@@ -122,7 +122,7 @@ Example: `nvidia`
 
 ### `shell` (optional)
 
-Set the shell to use for the command. Set it to `false` to pass the command directly to the `docker run` command. The default is `bash -e -c`.
+Set the shell to use for the command. The default is no shell. If you command uses multiple lines or shell-isms like output redirection then a shell of `/bin/sh -e -c` is used.
 
 Example: `powershell -Command`
 

--- a/hooks/command
+++ b/hooks/command
@@ -84,20 +84,36 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}" ]] ; then
   BUILDKITE_PLUGIN_DOCKER_SHELL="${BUILDKITE_PLUGIN_DOCKER_SHELL:-false}"
 fi
 
-BUILDKITE_PLUGIN_DOCKER_SHELL="${BUILDKITE_PLUGIN_DOCKER_SHELL:-bash -e -c}"
+BUILDKITE_PLUGIN_DOCKER_SHELL="${BUILDKITE_PLUGIN_DOCKER_SHELL:-}"
 
+# Detect shell characters and infer /bin/bash if no specific shell has been provided
+# shellcheck disable=SC1001
+if [[ -z "$BUILDKITE_PLUGIN_DOCKER_SHELL" ]] && [[ $BUILDKITE_COMMAND =~ [][\!\#\$\&\(\)\*\;\<\>\?\\\^\`\{\}] || $BUILDKITE_COMMAND =~ $'\n' ]] ; then
+  BUILDKITE_PLUGIN_DOCKER_SHELL="/bin/sh -e -c"
+fi
+
+# Disable the shell if it's turned off explicitly
 if [[ "${BUILDKITE_PLUGIN_DOCKER_SHELL}" =~ ^(false|off|0)$ ]] ; then
-  BUILDKITE_PLUGIN_DOCKER_SHELL=''
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
 fi
 
 args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
 
-if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" ]]; then
-  # shellcheck disable=SC2206 # We want the word splits
-  args+=(${BUILDKITE_PLUGIN_DOCKER_SHELL} "${BUILDKITE_COMMAND}")
+# If there is a shell defined, we tokenize the shell, but pass BUILDKITE_COMMAND as a flat string
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" ]]; then
+
+  # Tokenize shell using xargs to respect quoted strings
+  while IFS= read -rd '' token; do
+    [[ -n "$token" ]] && args+=("$token")
+  done < <(xargs printf '%s\0' <<< "$BUILDKITE_PLUGIN_DOCKER_SHELL")
+
+  args+=("${BUILDKITE_COMMAND}")
+
+# Otherwise we tokenize the BUILDKITE_COMMAND and pass it to docker as args
 else
-  # shellcheck disable=SC2206 # We want the word splits
-  args+=(${BUILDKITE_COMMAND})
+  while IFS= read -rd '' token; do
+    [[ -n "$token" ]] && args+=("$token")
+  done < <(xargs printf '%s\0' <<< "$BUILDKITE_COMMAND")
 fi
 
 echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,16 +3,16 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-# export DOCKER_STUB_DEBUG=/dev/tty
+export DOCKER_STUB_DEBUG=/dev/tty
 
 @test "Run command" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_COMMAND='command1 "a string"'
+  export BUILDKITE_COMMAND="command1 string"
   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -e -c 'command1 \"a string\"' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag command1 string : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -25,320 +25,339 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Run command without a workdir should not fail" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_COMMAND="command1 \"a string\""
-  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+# @test "Run command without a workdir should not fail" {
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_COMMAND="command1 \"a string\""
+#   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
 
-  stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -e -c 'command1 \"a string\"' : echo ran command in docker"
+#   stub docker \
+#     "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag command1 'a string' : echo ran command in docker"
 
-  run $PWD/hooks/command
+#   run $PWD/hooks/command
 
-  assert_success
-  assert_output --partial "ran command in docker"
+#   assert_success
+#   assert_output --partial "ran command in docker"
 
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-}
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+# }
 
-@test "Pull image first before running the command with mount-buildkite-agent disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
+# @test "Pull image first before running the command with mount-buildkite-agent disabled" {
+#   export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_COMMAND="pwd"
+
+#   stub docker \
+#     "pull image:tag : echo pulled latest image" \
+#     "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "pulled latest image"
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+# }
+
+
+# @test "Runs the command with mount-buildkite-agent disabled" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_COMMAND="pwd"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+# }
+
+# @test "Runs command with volumes" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
+# }
+
+# @test "Runs command with environment" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
+#   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=ANOTHER_TAG=llamas
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
+# }
+
+# @test "Runs command with user" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_USER=foo
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_USER
+# }
+
+# @test "Runs command with additional groups" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
+#   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
+#   unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
+# }
+
+# @test "Runs command with network that doesn't exist" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "network ls --quiet --filter 'name=foo' : echo " \
+#     "network create foo : echo creating network foo" \
+#     "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "creating network foo"
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_COMMAND
+#   unset BUILDKITE_PLUGIN_DOCKER_NETWORK
+# }
+
+# @test "Runs with debug mode" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "Enabling debug mode"
+#   assert_output --partial "$ docker run"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+#   unset BUILDKITE_PLUGIN_DOCKER_DEBUG
+#   unset BUILDKITE_COMMAND
+# }
+
+# @test "Runs with custom runtime" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+#   unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
+#   unset BUILDKITE_COMMAND
+# }
+
+# @test "Runs with entrypoint option" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag echo hello world : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+#   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
+#   unset BUILDKITE_COMMAND
+# }
+
+# @test "Runs with entrypoint option with shell" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
+#   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+#   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
+#   unset BUILDKITE_PLUGIN_DOCKER_SHELL
+#   unset BUILDKITE_COMMAND
+# }
+
+# @test "Runs with shell" {
+#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+#   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+#   export BUILDKITE_COMMAND="echo hello world"
+
+#   stub docker \
+#     "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+
+#   run $PWD/hooks/command
+
+#   assert_success
+#   assert_output --partial "ran command in docker"
+
+#   unstub docker
+#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+#   unset BUILDKITE_PLUGIN_DOCKER_SHELL
+#   unset BUILDKITE_COMMAND
+# }
+
+@test "Runs without shell but with multiple lines" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_COMMAND=$'echo hello world\nanother command'
 
   stub docker \
-    "pull image:tag : echo pulled latest image" \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c echo\ hello\ world\\nanother\ command' : echo ran command in docker"
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial "pulled latest image"
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-}
-
-
-@test "Runs the command with mount-buildkite-agent disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_COMMAND="pwd"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -e -c 'pwd' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-}
-
-@test "Runs command with volumes" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
-  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
-  export BUILDKITE_COMMAND="echo hello world; pwd"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag bash -e -c 'echo hello world; pwd' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
-}
-
-
-@test "Runs command with environment" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
-  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=ANOTHER_TAG=llamas
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag bash -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
-}
-
-@test "Runs command with user" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_USER=foo
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag bash -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_USER
-}
-
-@test "Runs command with additional groups" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
-  export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag bash -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
-  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
-}
-
-@test "Runs command with network that doesn't exist" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "network ls --quiet --filter 'name=foo' : echo " \
-    "network create foo : echo creating network foo" \
-    "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag bash -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "creating network foo"
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_NETWORK
-}
-
-
-@test "Runs with debug mode" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "Enabling debug mode"
-  assert_output --partial "$ docker run"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_DEBUG
-  unset BUILDKITE_COMMAND
-}
-
-@test "Runs with custom runtime" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag bash -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
-  unset BUILDKITE_COMMAND
-}
-
-@test "Runs with entrypoint option w/o shell by default" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag echo hello world : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
-  unset BUILDKITE_COMMAND
-}
-
-@test "Runs with entrypoint option w/ explicit shell" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
-  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs with shell option" {
+@test "Runs without shell but shell characters in command" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
-  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_COMMAND="echo hello world > my_file"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
-}
-
-@test "Runs with shell disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_SHELL=false
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag echo hello world : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'echo hello world > my_file' : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-export DOCKER_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
 
 @test "Run command" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
@@ -25,308 +25,308 @@ export DOCKER_STUB_DEBUG=/dev/tty
   unset BUILDKITE_COMMAND
 }
 
-# @test "Run command without a workdir should not fail" {
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_COMMAND="command1 \"a string\""
-#   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag command1 'a string' : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-# }
-
-# @test "Pull image first before running the command with mount-buildkite-agent disabled" {
-#   export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_COMMAND="pwd"
-
-#   stub docker \
-#     "pull image:tag : echo pulled latest image" \
-#     "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "pulled latest image"
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-# }
-
-
-# @test "Runs the command with mount-buildkite-agent disabled" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_COMMAND="pwd"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-# }
-
-# @test "Runs command with volumes" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
-# }
-
-# @test "Runs command with environment" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
-#   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=ANOTHER_TAG=llamas
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-#   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
-# }
-
-# @test "Runs command with user" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_USER=foo
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_USER
-# }
-
-# @test "Runs command with additional groups" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
-#   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
-#   unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
-# }
-
-# @test "Runs command with network that doesn't exist" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "network ls --quiet --filter 'name=foo' : echo " \
-#     "network create foo : echo creating network foo" \
-#     "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "creating network foo"
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_COMMAND
-#   unset BUILDKITE_PLUGIN_DOCKER_NETWORK
-# }
-
-# @test "Runs with debug mode" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "Enabling debug mode"
-#   assert_output --partial "$ docker run"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-#   unset BUILDKITE_PLUGIN_DOCKER_DEBUG
-#   unset BUILDKITE_COMMAND
-# }
-
-# @test "Runs with custom runtime" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-#   unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
-#   unset BUILDKITE_COMMAND
-# }
-
-# @test "Runs with entrypoint option" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag echo hello world : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-#   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
-#   unset BUILDKITE_COMMAND
-# }
-
-# @test "Runs with entrypoint option with shell" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
-#   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-#   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
-#   unset BUILDKITE_PLUGIN_DOCKER_SHELL
-#   unset BUILDKITE_COMMAND
-# }
-
-# @test "Runs with shell" {
-#   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
-#   export BUILDKITE_COMMAND="echo hello world"
-
-#   stub docker \
-#     "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
-
-#   run $PWD/hooks/command
-
-#   assert_success
-#   assert_output --partial "ran command in docker"
-
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-#   unset BUILDKITE_PLUGIN_DOCKER_SHELL
-#   unset BUILDKITE_COMMAND
-# }
+@test "Run command without a workdir should not fail" {
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_COMMAND="command1 \"a string\""
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag command1 'a string' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+}
+
+@test "Pull image first before running the command with mount-buildkite-agent disabled" {
+  export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_COMMAND="pwd"
+
+  stub docker \
+    "pull image:tag : echo pulled latest image" \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "pulled latest image"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+}
+
+
+@test "Runs the command with mount-buildkite-agent disabled" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_COMMAND="pwd"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag pwd : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+}
+
+@test "Runs command with volumes" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
+  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
+}
+
+@test "Runs command with environment" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=ANOTHER_TAG=llamas
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
+}
+
+@test "Runs command with user" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_USER=foo
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_USER
+}
+
+@test "Runs command with additional groups" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
+  export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
+  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
+}
+
+@test "Runs command with network that doesn't exist" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "network ls --quiet --filter 'name=foo' : echo " \
+    "network create foo : echo creating network foo" \
+    "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "creating network foo"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_NETWORK
+}
+
+@test "Runs with debug mode" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "Enabling debug mode"
+  assert_output --partial "$ docker run"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_DEBUG
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with custom runtime" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with entrypoint option" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag echo hello world : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with entrypoint option with shell" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
+  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with shell" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
 
 @test "Runs without shell but with multiple lines" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app


### PR DESCRIPTION
This defaults to no `shell`, but detects if a command is needed based on it containing shell-like chars and uses `/bin/sh -e -c`.

This uses the `xargs` shell-string parsing trick from https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/165. 

My only real concern here is that we match shell characters indiscriminately, so even something like `/my-command --flag="[blah]"` will trigger it, despite the square braces being in a quoted string. 