### PR TITLE
Add a command parameter and support arrays for command and shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ steps:
         workdir: /app
 ```
 
+If you want to control how your command is passed to the docker container, you can use the `command` parameter on the plugin directly:
+
+```yml
+steps:
+    plugins:
+      docker#v1.4.0:
+        image: "koalaman/shellcheck"
+        command: ["--exclude=SC2207", "/app/script.sh"]
+        workdir: /app
+```
+
 You can pass in additional environment variables:
 
 ```yml
@@ -104,7 +115,7 @@ Example: `docker`
 
 ### `network` (optional)
 
-Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details. 
+Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details.
 
 Example: `test-network`
 
@@ -122,15 +133,22 @@ Example: `nvidia`
 
 ### `shell` (optional)
 
-Set the shell to use for the command. Set it to `false` to pass the command directly to the `docker run` command. The default is `bash -e -c`.
+Set the shell to use for the command. Set it to `false` to pass the command directly to the `docker run` command. The default is `["/bin/sh", "-e", "-c"]` unless you have provided an `entrypoint` or `command`.
 
-Example: `powershell -Command`
+Example: `["powershell", "-Command"]`
 
 ### `entrypoint` (optional)
 
 Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details.
 
-Example: `/my/custom/entrypoint.sh`
+Example: `["/my/custom/entrypoint.sh", "-arg"]`
+
+
+### `command` (optional)
+
+Override the image’s default command, and defaults the `shell` option to `false`.
+
+Example: `["/bin/mycommand", "-c", "test"]`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you want to control how your command is passed to the docker container, you c
 
 ```yml
 steps:
-    plugins:
+  - plugins:
       docker#v1.4.0:
         image: "koalaman/shellcheck"
         command: ["--exclude=SC2207", "/app/script.sh"]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Example: `["powershell", "-Command"]`
 
 Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details.
 
-Example: `["/my/custom/entrypoint.sh", "-arg"]`
+Example: `/my/custom/entrypoint.sh`
 
 
 ### `command` (optional)

--- a/hooks/command
+++ b/hooks/command
@@ -2,6 +2,24 @@
 
 set -euo pipefail
 
+# Reads either a value or a list from plugin config
+function plugin_read_list() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      echo "${!parameter}"
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    echo "${!prefix}"
+  fi
+}
+
 debug_mode='off'
 if [[ "${BUILDKITE_PLUGIN_DOCKER_DEBUG:-false}" =~ (true|on|1) ]] ; then
   echo "--- :hammer: Enabling debug mode"
@@ -78,29 +96,71 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_RUNTIME:-}" ]] ; then
   args+=("--runtime" "${BUILDKITE_PLUGIN_DOCKER_RUNTIME:-}")
 fi
 
-# Support docker run --entrypoint
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}" ]] ; then
-  args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}")
-  BUILDKITE_PLUGIN_DOCKER_SHELL="${BUILDKITE_PLUGIN_DOCKER_SHELL:-false}"
+entrypoint=()
+
+# Parse entrypoint if provided
+for arg in $(plugin_read_list BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT) ; do
+  entrypoint+=("$arg")
+done
+
+if [[ ${#entrypoint[@]} -gt 0 ]] ; then
+  args+=("--entrypoint")
+  for entrypoint_arg in "${entrypoint[@]}" ; do
+    args+=("$entrypoint_arg")
+  done
 fi
 
-BUILDKITE_PLUGIN_DOCKER_SHELL="${BUILDKITE_PLUGIN_DOCKER_SHELL:-bash -e -c}"
+shell=()
+shell_disabled=''
 
-if [[ "${BUILDKITE_PLUGIN_DOCKER_SHELL}" =~ ^(false|off|0)$ ]] ; then
-  BUILDKITE_PLUGIN_DOCKER_SHELL=''
-fi
-
-args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
-
-if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" ]]; then
-  # shellcheck disable=SC2206 # We want the word splits
-  args+=(${BUILDKITE_PLUGIN_DOCKER_SHELL} "${BUILDKITE_COMMAND}")
+# Either disable the shell or parse the shell arguments
+if [[ -z "${BUILDKITE_COMMAND}" ]] || [[ ! "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" =~ ^(false|off|0)$ ]] ; then
+  shell_disabled=1
 else
-  # shellcheck disable=SC2206 # We want the word splits
-  args+=(${BUILDKITE_COMMAND})
+  for arg in $(plugin_read_list BUILDKITE_PLUGIN_DOCKER_SHELL) ; do
+    shell+=("$arg")
+  done
 fi
 
-echo "--- :docker: Running ${BUILDKITE_COMMAND} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+# Set a default shell if one is needed
+if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
+  shell+=("/bin/sh" "-e" "-c")
+fi
+
+command=()
+
+# Parse plugin command if provided
+for arg in $(plugin_read_list BUILDKITE_PLUGIN_DOCKER_COMMAND) ; do
+  command+=("$arg")
+done
+
+if [[ ${#command[@]} -gt 0 ]] && [[ -n "${BUILDKITE_COMMAND}" ]] ; then
+  echo "+++ Error: Can't use both a step level command and the command parameter of the plugin"
+  exit 1
+fi
+
+# Assemble the shell and command arguments into the docker arguments
+
+display_command=()
+
+if [[ ${#shell[@]} -gt 0 ]] ; then
+  for shell_arg in "${shell[@]}" ; do
+    args+=("$shell_arg")
+    display_command+=("$shell_arg")
+  done
+fi
+
+if [[ -n "${BUILDKITE_COMMAND}" ]] ; then
+  args+=("${BUILDKITE_COMMAND}")
+  display_command+=("'${BUILDKITE_COMMAND}'")
+elif [[ ${#command[@]} -gt 0 ]] ; then
+  for command_arg in "${command[@]}" ; do
+    args+=("$command_arg")
+    display_command+=("${command_arg}")
+  done
+fi
+
+echo "--- :docker: Running ${display_command[*]} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 
 if [[ "${debug_mode:-off}" =~ (on) ]] ; then
   echo "$ docker run ${args[*]}" >&2

--- a/hooks/command
+++ b/hooks/command
@@ -2,22 +2,26 @@
 
 set -euo pipefail
 
-# Reads either a value or a list from plugin config
-function plugin_read_list() {
+# Reads either a value or a list from plugin config into a global result array
+# Returns success if values were read
+function plugin_read_list_into_result() {
   local prefix="$1"
   local parameter="${prefix}_0"
+  result=()
 
   if [[ -n "${!parameter:-}" ]]; then
     local i=0
     local parameter="${prefix}_${i}"
     while [[ -n "${!parameter:-}" ]]; do
-      echo "${!parameter}"
+      result+=("${!parameter}")
       i=$((i+1))
       parameter="${prefix}_${i}"
     done
   elif [[ -n "${!prefix:-}" ]]; then
-    echo "${!prefix}"
+    result+=("${!prefix}")
   fi
+
+  [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
 debug_mode='off'
@@ -96,43 +100,55 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_RUNTIME:-}" ]] ; then
   args+=("--runtime" "${BUILDKITE_PLUGIN_DOCKER_RUNTIME:-}")
 fi
 
-entrypoint=()
+shell=()
+shell_disabled=1
 
-# Parse entrypoint if provided
-for arg in $(plugin_read_list BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT) ; do
-  entrypoint+=("$arg")
-done
-
-if [[ ${#entrypoint[@]} -gt 0 ]] ; then
-  args+=("--entrypoint")
-  for entrypoint_arg in "${entrypoint[@]}" ; do
-    args+=("$entrypoint_arg")
-  done
+if [[ -n "${BUILDKITE_COMMAND}" ]]; then
+  echo "Non-empty BUILDKITE_COMMAND"
+  shell_disabled=''
 fi
 
-shell=()
-shell_disabled=''
-
-# Either disable the shell or parse the shell arguments
-if [[ -z "${BUILDKITE_COMMAND}" ]] || [[ ! "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" =~ ^(false|off|0)$ ]] ; then
+# Handle entrypoint if provided, and default shell to disabled
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}" ]] ; then
+  args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}")
   shell_disabled=1
-else
-  for arg in $(plugin_read_list BUILDKITE_PLUGIN_DOCKER_SHELL) ; do
+fi
+
+# Handle shell being disabled
+if [[ "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" =~ ^(false|off|0)$ ]] ; then
+  echo "Shell explicitly disabled"
+  shell_disabled=1
+
+# Handle shell being provided as a string or list
+elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SHELL ; then
+  echo "Got a shell"
+  shell_disabled=''
+  for arg in "${result[@]}" ; do
     shell+=("$arg")
   done
 fi
 
+# Add the image in before the shell and command
+args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
+
 # Set a default shell if one is needed
 if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
-  shell+=("/bin/sh" "-e" "-c")
+  shell=("/bin/sh" "-e" "-c")
 fi
+
+echo "SHELL disabled? ${shell_disabled}"
+echo -n "SHELL IS "
+printf "[%s] " "${shell[@]:-}"
+echo
 
 command=()
 
 # Parse plugin command if provided
-for arg in $(plugin_read_list BUILDKITE_PLUGIN_DOCKER_COMMAND) ; do
-  command+=("$arg")
-done
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMMAND ; then
+  for arg in "${result[@]}" ; do
+    command+=("$arg")
+  done
+fi
 
 if [[ ${#command[@]} -gt 0 ]] && [[ -n "${BUILDKITE_COMMAND}" ]] ; then
   echo "+++ Error: Can't use both a step level command and the command parameter of the plugin"

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,8 +15,10 @@ configuration:
       type: boolean
     mounts:
       type: array
+    command:
+      type: [string, array]
     entrypoint:
-      type: string
+      type: [string, array]
     environment:
       type: array
     user:
@@ -30,7 +32,7 @@ configuration:
     runtime:
       type: string
     shell:
-      type: string
+      type: [string, array]
   required:
     - image
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,7 +18,7 @@ configuration:
     command:
       type: [string, array]
     entrypoint:
-      type: [string, array]
+      type: string
     environment:
       type: array
     user:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -5,14 +5,14 @@ load '/usr/local/lib/bats/load.bash'
 # Uncomment to enable stub debug output:
 # export DOCKER_STUB_DEBUG=/dev/tty
 
-@test "Run command" {
+@test "Run with BUILDKITE_COMMAND" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND='command1 "a string"'
   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -e -c 'command1 \"a string\"' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -25,13 +25,13 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Run command without a workdir should not fail" {
+@test "Run with BUILDKITE_COMMAND without a workdir should not fail" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND="command1 \"a string\""
   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
 
   stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID  --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag bash -e -c 'command1 \"a string\"' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -44,7 +44,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Pull image first before running the command with mount-buildkite-agent disabled" {
+@test "Pull image first before running BUILDKITE_COMMAND with mount-buildkite-agent disabled" {
   export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
@@ -53,7 +53,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub docker \
     "pull image:tag : echo pulled latest image" \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -69,15 +69,14 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 }
 
-
-@test "Runs the command with mount-buildkite-agent disabled" {
+@test "Runs BUILDKITE_COMMAND with mount-buildkite-agent disabled" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -91,7 +90,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 }
 
-@test "Runs command with volumes" {
+@test "Runs BUILDKITE_COMMAND with volumes" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -100,7 +99,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag bash -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -115,8 +114,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
-
-@test "Runs command with environment" {
+@test "Runs BUILDKITE_COMMAND with environment" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -125,7 +123,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag bash -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -140,7 +138,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
-@test "Runs command with user" {
+@test "Runs BUILDKITE_COMMAND with user" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -148,7 +146,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag bash -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -162,7 +160,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
-@test "Runs command with additional groups" {
+@test "Runs BUILDKITE_COMMAND with additional groups" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -171,7 +169,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag bash -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -186,7 +184,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
 }
 
-@test "Runs command with network that doesn't exist" {
+@test "Runs BUILDKITE_COMMAND with network that doesn't exist" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -196,7 +194,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "network ls --quiet --filter 'name=foo' : echo " \
     "network create foo : echo creating network foo" \
-    "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag bash -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -211,8 +209,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_NETWORK
 }
 
-
-@test "Runs with debug mode" {
+@test "Runs BUILDKITE_COMMAND with debug mode" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -220,7 +217,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag bash -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -236,7 +233,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs with custom runtime" {
+@test "Runs BUILDKITE_COMMAND with custom runtime" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -244,7 +241,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag bash -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -259,7 +256,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs with entrypoint option w/o shell by default" {
+@test "Runs BUILDKITE_COMMAND with entrypoint without explicit shell" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -267,7 +264,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag echo hello world : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -282,7 +279,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs with entrypoint option w/ explicit shell" {
+@test "Runs BUILDKITE_COMMAND with entrypoint with explicit shell" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -291,7 +288,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -307,11 +304,13 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs with shell option" {
+@test "Runs BUILDKITE_COMMAND with shell option as array" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_1='-a'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_2='-b'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
@@ -330,7 +329,30 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs with shell disabled" {
+@test "Runs BUILDKITE_COMMAND with shell option as string" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs BUILDKITE_COMMAND with shell disabled" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -338,7 +360,109 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag echo hello world : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with a command as a string" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND="echo hello world"
+  export BUILDKITE_COMMAND=
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with a command as an array" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND_1="hello world"
+  export BUILDKITE_COMMAND=
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag echo 'hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with a command as an array with a shell" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND_1="hello world"
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_1='-a'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_2='-b'
+  export BUILDKITE_COMMAND=
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_SHELL
+  unset BUILDKITE_COMMAND
+}
+
+@test "Runs with a command as an array with a shell and an entrypoint" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
+  export BUILDKITE_PLUGIN_DOCKER_COMMAND_1="hello world"
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_1='-a'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_2='-b'
+  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT='llamas.sh'
+  export BUILDKITE_COMMAND=
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint llamas.sh image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 


### PR DESCRIPTION
It dawned on @toolmantim and I that a good solution to the question of whether this plugin and `docker-compose` should default to a shell is the following:

* If a command is provided via the step-level command, assume a shell, as we tend to do things like `yarn install && yarn start` in examples:

```yml
steps:
  - command: yarn install && yarn run test
    plugins:
      docker#v1.4.0:
        image: "node:7"
        workdir: /app
```

The above will translate to `/bin/sh -e -c 'yarn install && yarn run test'` in the container. This will also support multiple line commands.

* If no step level command is provided, no shell is used. If you want control over exactly what command is passed to docker (e.g how the command is split into arguments), you can use the new plugin level `command` this PR introduces:

```yml
steps:
  - plugins:
      docker#v1.4.0:
        image: "koalaman/shellcheck"
        command: ["--exclude=SC2207", "/app/script.sh"]
        workdir: /app
```

This avoids us having to do any shell word parsing, which is horrible for complexity and security. 

The new array syntax is also applied to `entrypoint` and `shell`:

```yml
steps:
  - plugins:
       docker#v1.4.0:
         image: "alpine"
         command: ["echo", "hello", "world"]
         shell: ["/bin/sh", "-c"]
```