### PR TITLE
Skip mounting the current checkout dir if custom mounts are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Whether to automatically mount the `buildkite-agent` binary from the host agent 
 
 ### `mounts` (optional)
 
-Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter, except relative paths are allowed. in `SOURCE`.
+Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter, with the addition of relative paths being converted to their full-path (e.g `.:/app`).
 
 Example: `/var/run/docker.sock:/var/run/docker.sock`
 

--- a/hooks/command
+++ b/hooks/command
@@ -24,6 +24,18 @@ function plugin_read_list_into_result() {
   [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
+# docker's -v arguments don't do local path expansion, so we add very simple support for .
+expand_relative_volume_path() {
+  local path="$1"
+  if [[ $path =~ ^\.: ]] ; then
+    printf "%s" "${PWD}${path#.}"
+  elif [[ $path =~ ^\.(/|\\) ]] ; then
+    printf "%s" "${PWD}/${path#.}"
+  else
+    echo "$path"
+  fi
+}
+
 debug_mode='off'
 if [[ "${BUILDKITE_PLUGIN_DOCKER_DEBUG:-false}" =~ (true|on|1) ]] ; then
   echo "--- :hammer: Enabling debug mode"
@@ -33,9 +45,26 @@ fi
 args=(
   "-it"
   "--rm"
-  "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
-  "--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}"
 )
+
+default_mounts=1
+
+# Parse mounts and add them to the docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
+  default_mounts=''
+  for arg in "${result[@]}" ; do
+    args+=( "--volume" "$(expand_relative_volume_path "${arg}")" )
+  done
+
+# By default, mount $PWD onto $WORKDIR
+else
+  args+=( "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}" )
+fi
+
+# Set workdir if one is provided or if mounts is the default
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ -n "$default_mounts" ]]; then
+  args+=("--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}")
+fi
 
 # Support docker run --user
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USER:-}" ]] ; then
@@ -75,13 +104,6 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ (true|on|1) ]] ; then
   echo "--- :docker: Pulling ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
   docker pull "${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 fi
-
-# Parse extra mounts and add them to the docker args
-while IFS='=' read -r name _ ; do
-  if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_MOUNTS_[0-9]+) ]] ; then
-    args+=( "--volume" "${!name}" )
-  fi
-done < <(env | sort)
 
 # Parse network and create it if it don't exist.
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}" ]] ; then

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,31 +3,11 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-# export DOCKER_STUB_DEBUG=/dev/tty
+export DOCKER_STUB_DEBUG=/dev/tty
 
 @test "Run with BUILDKITE_COMMAND" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND='command1 "a string"'
-  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
-
-  stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-}
-
-@test "Run with BUILDKITE_COMMAND without a workdir should not fail" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_COMMAND="command1 \"a string\""
   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
 
   stub docker \
@@ -39,21 +19,19 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
 }
 
 @test "Pull image first before running BUILDKITE_COMMAND with mount-buildkite-agent disabled" {
   export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
     "pull image:tag : echo pulled latest image" \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -63,20 +41,18 @@ load '/usr/local/lib/bats/load.bash'
 
   unstub docker
   unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 }
 
 @test "Runs BUILDKITE_COMMAND with mount-buildkite-agent disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -84,7 +60,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
@@ -94,12 +69,12 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/hello:/hello-world
+  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=.:/app
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --volume /hello:/hello-world --volume /var/run/docker.sock:/var/run/docker.sock image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/app --volume /var/run/docker.sock:/var/run/docker.sock --workdir /app image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -107,7 +82,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
@@ -115,7 +89,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with environment" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
@@ -123,7 +96,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -131,7 +104,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
@@ -139,14 +111,13 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with user" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_USER=foo
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app -u foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir -u foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -154,14 +125,12 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
 @test "Runs BUILDKITE_COMMAND with additional groups" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
@@ -169,7 +138,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --group-add foo --group-add bar image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --group-add foo --group-add bar image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -177,7 +146,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
@@ -185,7 +153,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with network that doesn't exist" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
@@ -194,7 +161,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "network ls --quiet --filter 'name=foo' : echo " \
     "network create foo : echo creating network foo" \
-    "run -it --rm --volume $PWD:/app --workdir /app --network foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --network foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -203,21 +170,19 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_DOCKER_NETWORK
 }
 
 @test "Runs BUILDKITE_COMMAND with debug mode" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -226,7 +191,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "$ docker run"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_DEBUG
@@ -234,14 +198,13 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with custom runtime" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --runtime custom_runtime image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --runtime custom_runtime image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -249,7 +212,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
@@ -257,14 +219,13 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with entrypoint without explicit shell" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -272,7 +233,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
@@ -280,7 +240,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with entrypoint with explicit shell" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
@@ -288,7 +247,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint /some/custom/entry/point image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -296,7 +255,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
@@ -305,7 +263,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with shell option as array" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
@@ -314,7 +271,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -322,7 +279,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -330,14 +286,13 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with shell option as string" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -345,7 +300,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -353,14 +307,13 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs BUILDKITE_COMMAND with shell disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL=false
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -368,7 +321,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -376,14 +328,13 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs with a command as a string" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND="echo hello world"
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -391,7 +342,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -399,7 +349,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs with a command as an array" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
@@ -407,7 +356,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag echo 'hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -415,7 +364,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -423,7 +371,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs with a command as an array with a shell" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
@@ -434,7 +381,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -442,7 +389,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -450,7 +396,6 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Runs with a command as an array with a shell and an entrypoint" {
-  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
@@ -462,7 +407,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --volume $PWD:/app --workdir /app --entrypoint llamas.sh image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --entrypoint llamas.sh image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -470,7 +415,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_WORKDIR
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-export DOCKER_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
 
 @test "Run with BUILDKITE_COMMAND" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag


### PR DESCRIPTION
This changes the default behaviour of the plugin around how the current checkout directory is mounted into the container.

Currently, `$PWD` is mounted to whatever `workdir` is set to, which defaults to `/workdir`. With the changes in this PR, that step is skipped if custom volumes are provided. This let's power users choose what source directory is mounted in and where it goes in the container and leaves `workdir` to serve it's regular Docker purpose, which is to change the working directory in the docker container.

Additionally, this PR adds support for dot relative paths in the `mounts` mounts, so that things like `.:/app` work ok. 

**Breaking changes:** 
* Calls with custom `mounts` will now now not do the default "mount $PWD to workdir" behaviour
