### PR TITLE
Arrays only for command and shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Example: `/app`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true`. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
-### `mounts` (optional)
+### `mounts` (optional, array)
 
 Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter, with the addition of relative paths being converted to their full-path (e.g `.:/app`).
 
@@ -90,7 +90,7 @@ Example: `/var/run/docker.sock:/var/run/docker.sock`
 
 Whether to always pull the latest image before running the command. Useful if the image has a `latest` tag. The default is false, the image will only get pulled if not present.
 
-### `environment` (optional)
+### `environment` (optional, array)
 
 An array of additional environment variables to pass into to the docker container. Items can be specified as either `KEY` or `KEY=value`. Each entry corresponds to a Docker CLI `--env` parameter. Values specified as variable names will be passed through from the outer environment.
 
@@ -126,7 +126,7 @@ Specify an explicit docker runtime. See the [docker run options documentation](h
 
 Example: `nvidia`
 
-### `shell` (optional)
+### `shell` (optional, array)
 
 Set the shell to use for the command. Set it to `false` to pass the command directly to the `docker run` command. The default is `["/bin/sh", "-e", "-c"]` unless you have provided an `entrypoint` or `command`.
 
@@ -138,7 +138,7 @@ Override the image’s default entrypoint, and defaults the `shell` option to `f
 
 Example: `/my/custom/entrypoint.sh`
 
-### `command` (optional)
+### `command` (optional, array)
 
 Override the image’s default command, and defaults the `shell` option to `false`.
 

--- a/hooks/command
+++ b/hooks/command
@@ -2,24 +2,24 @@
 
 set -euo pipefail
 
-# Reads either a value or a list from plugin config into a global result array
+# Reads a list from plugin config into a global result array
 # Returns success if values were read
 function plugin_read_list_into_result() {
   local prefix="$1"
-  local parameter="${prefix}_0"
+  local i=0
+  local parameter="${prefix}_${i}"
   result=()
 
-  if [[ -n "${!parameter:-}" ]]; then
-    local i=0
-    local parameter="${prefix}_${i}"
-    while [[ -n "${!parameter:-}" ]]; do
-      result+=("${!parameter}")
-      i=$((i+1))
-      parameter="${prefix}_${i}"
-    done
-  elif [[ -n "${!prefix:-}" ]]; then
-    result+=("${!prefix}")
+  if [[ -n "${!prefix:-}" ]] ; then
+    echo "🚨 Plugin received a string for $prefix, expected an array" >&2
+    exit 1
   fi
+
+  while [[ -n "${!parameter:-}" ]]; do
+    result+=("${!parameter}")
+    i=$((i+1))
+    parameter="${prefix}_${i}"
+  done
 
   [[ ${#result[@]} -gt 0 ]] || return 1
 }

--- a/hooks/command
+++ b/hooks/command
@@ -47,6 +47,12 @@ args=(
   "--rm"
 )
 
+# Show a helpful error message if string version of mounts is used
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" ]] ; then
+  echo -n "🚨 The Docker Plugin’s mounts configuration option must be an array."
+  exit 1
+fi
+
 default_mounts=1
 
 # Parse mounts and add them to the docker args
@@ -139,6 +145,13 @@ fi
 if [[ "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" =~ ^(false|off|0)$ ]] ; then
   shell_disabled=1
 
+# Show a helpful error message if a string version of shell is used
+elif [[ -n "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" ]] ; then
+  echo -n "🚨 The Docker Plugin’s shell configuration option can no longer be specified as a string, "
+  echo -n "but only as an array. Please update your pipeline.yml to use an array, "
+  echo "for example: [\"/bin/sh\", \"-e\", \"-u\"]."
+  exit 1
+
 # Handle shell being provided as a string or list
 elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SHELL ; then
   shell_disabled=''
@@ -156,6 +169,12 @@ if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
 fi
 
 command=()
+
+# Show a helpful error message if string version of command is used
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMMAND:-}" ]] ; then
+  echo -n "🚨 The Docker Plugin’s command configuration option must be an array."
+  exit 1
+fi
 
 # Parse plugin command if provided
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMMAND ; then

--- a/hooks/command
+++ b/hooks/command
@@ -150,6 +150,9 @@ elif [[ -n "${BUILDKITE_PLUGIN_DOCKER_SHELL:-}" ]] ; then
   echo -n "🚨 The Docker Plugin’s shell configuration option can no longer be specified as a string, "
   echo -n "but only as an array. Please update your pipeline.yml to use an array, "
   echo "for example: [\"/bin/sh\", \"-e\", \"-u\"]."
+  echo
+  echo -n "Note that the docker plugin will infer a shell if one is required, so you might be able to remove"
+  echo "the option entirely"
   exit 1
 
 # Handle shell being provided as a string or list

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,7 +16,7 @@ configuration:
     mounts:
       type: array
     command:
-      type: [string, array]
+      type: array
     entrypoint:
       type: string
     environment:
@@ -32,7 +32,7 @@ configuration:
     runtime:
       type: string
     shell:
-      type: [string, array]
+      type: [boolean, array]
   required:
     - image
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -243,11 +243,13 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
-  export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_1='-a'
+  export BUILDKITE_PLUGIN_DOCKER_SHELL_2='-b'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -262,7 +264,7 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs BUILDKITE_COMMAND with shell option as array" {
+@test "Runs BUILDKITE_COMMAND with shell" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
@@ -291,15 +293,11 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
   export BUILDKITE_COMMAND="echo hello world"
 
-  stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag 'custom-bash -a -b' 'echo hello world' : echo ran command in docker"
-
   run $PWD/hooks/command
 
-  assert_success
-  assert_output --partial "ran command in docker"
+  assert_failure
+  assert_output --partial "expected an array"
 
-  unstub docker
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL
@@ -333,15 +331,11 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_COMMAND="echo hello world"
   export BUILDKITE_COMMAND=
 
-  stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir image:tag 'echo hello world' : echo ran command in docker"
-
   run $PWD/hooks/command
 
-  assert_success
-  assert_output --partial "ran command in docker"
+  assert_failure
+  assert_output --partial "expected an array"
 
-  unstub docker
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
   unset BUILDKITE_PLUGIN_DOCKER_SHELL

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -296,7 +296,7 @@ load '/usr/local/lib/bats/load.bash'
   run $PWD/hooks/command
 
   assert_failure
-  assert_output --partial "expected an array"
+  assert_output --partial "shell configuration option can no longer be specified as a string, but only as an array"
 
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
@@ -334,7 +334,7 @@ load '/usr/local/lib/bats/load.bash'
   run $PWD/hooks/command
 
   assert_failure
-  assert_output --partial "expected an array"
+  assert_output --partial "command configuration option must be an array"
 
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT


### PR DESCRIPTION
In the spirit of simplicity, this requires the array syntax to be provided for `command` and `shell`. Previous string values (which required tokenizing) will result in an error like:

> 🚨The Docker Plugin’s shell configuration option can no longer be specified as a string, but only as an array. Please update your pipeline.yml to use an array, for example: ["/bin/sh", "-e", "-u"].
>
> Note that the docker plugin will infer a shell if one is required, so you might be able to remove the option entirely.

**Breaking changes:**
* This will cause `exit 1` on most pipelines that use a `shell` directive. 