### PR TITLE
Allow mounts to be explicitly disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ steps:
           - /var/run/docker.sock:/var/run/docker.sock
 ```
 
+You can disable all mounts, including the default by setting `mounts` to `false`:
+
+```yml
+steps:
+  - command: "npm start"
+    plugins:
+      docker#v1.4.0:
+        image: "node:7"
+        mounts: false
+```
+
 ## Configuration
 
 ### `image` (required)
@@ -80,7 +91,7 @@ Example: `/app`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true`. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
-### `mounts` (optional, array)
+### `mounts` (optional, array or bool)
 
 Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter, with the addition of relative paths being converted to their full-path (e.g `.:/app`).
 

--- a/hooks/command
+++ b/hooks/command
@@ -47,13 +47,13 @@ args=(
   "--rm"
 )
 
+default_mounts=1
+
 # Show a helpful error message if string version of mounts is used
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" ]] ; then
-  echo -n "🚨 The Docker Plugin’s mounts configuration option must be an array."
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" =~ ^(true|false)$ ]] ; then
+  echo -n "🚨 The Docker Plugin’s mounts configuration option must be an array or a boolean."
   exit 1
 fi
-
-default_mounts=1
 
 # Parse mounts and add them to the docker args
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
@@ -63,7 +63,7 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
   done
 
 # By default, mount $PWD onto $WORKDIR
-else
+elif [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" != "false  " ]] ; then
   args+=( "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}" )
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,7 +14,7 @@ configuration:
     mount-buildkite-agent:
       type: boolean
     mounts:
-      type: array
+      type: [boolean,array]
     command:
       type: array
     entrypoint:


### PR DESCRIPTION
This allows for mounts to be entirely disabled, including the default mount:

```yml
steps:
  - command: "npm start"
    plugins:
      docker#v1.4.0:
        image: "node:7"
        mounts: false
```