### PR TITLE
Rename mounts to volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ steps:
       docker#v1.4.0:
         image: "node:7"
         workdir: /app
-        mounts:
+        volumes:
           - ./code:/app
         environment:
           - MY_SECRET_KEY
           - MY_SPECIAL_BUT_PUBLIC_VALUE=kittens
 ```
 
-You can pass in additional volume mounts. This disables the default mount behaviour of mounting `$PWD` to `/workdir`. This is useful for docker-in-docker:
+You can pass in additional volumes to be mounted. This disables the default mount behaviour of mounting `$PWD` to `/workdir`. This is useful for docker-in-docker:
 
 ```yml
 steps:
@@ -57,7 +57,7 @@ steps:
     plugins:
       docker#v1.4.0:
         image: "docker:latest"
-        mounts:
+        volumes:
           - .:/work
           - /var/run/docker.sock:/var/run/docker.sock
 ```
@@ -80,7 +80,7 @@ Example: `/app`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true`. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
-### `mounts` (optional, array)
+### `volumes` (optional, array)
 
 Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter, with the addition of relative paths being converted to their full-path (e.g `.:/app`).
 

--- a/hooks/command
+++ b/hooks/command
@@ -5,20 +5,22 @@ set -euo pipefail
 # Reads a list from plugin config into a global result array
 # Returns success if values were read
 function plugin_read_list_into_result() {
-  local prefix="$1"
-  local i=0
-  local parameter="${prefix}_${i}"
   result=()
 
-  if [[ -n "${!prefix:-}" ]] ; then
-    echo "🚨 Plugin received a string for $prefix, expected an array" >&2
-    exit 1
-  fi
+  for prefix in "$@" ; do
+    local i=0
+    local parameter="${prefix}_${i}"
 
-  while [[ -n "${!parameter:-}" ]]; do
-    result+=("${!parameter}")
-    i=$((i+1))
-    parameter="${prefix}_${i}"
+    if [[ -n "${!prefix:-}" ]] ; then
+      echo "🚨 Plugin received a string for $prefix, expected an array" >&2
+      exit 1
+    fi
+
+    while [[ -n "${!parameter:-}" ]]; do
+      result+=("${!parameter}")
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
   done
 
   [[ ${#result[@]} -gt 0 ]] || return 1
@@ -47,17 +49,21 @@ args=(
   "--rm"
 )
 
-# Show a helpful error message if string version of mounts is used
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" ]] ; then
   echo -n "🚨 The Docker Plugin’s mounts configuration option must be an array."
   exit 1
 fi
 
-default_mounts=1
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" ]] ; then
+  echo -n "🚨 The Docker Plugin’s volumes configuration option must be an array."
+  exit 1
+fi
 
-# Parse mounts and add them to the docker args
-if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
-  default_mounts=''
+default_volumes=1
+
+# Parse volumes (and deprecated mounts) and add them to the docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
+  default_volumes=''
   for arg in "${result[@]}" ; do
     args+=( "--volume" "$(expand_relative_volume_path "${arg}")" )
   done
@@ -68,7 +74,7 @@ else
 fi
 
 # Set workdir if one is provided or if mounts is the default
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ -n "$default_mounts" ]]; then
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ -n "$default_volumes" ]]; then
   args+=("--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}")
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,8 @@ configuration:
       type: boolean
     mounts:
       type: array
+    volumes:
+      type: array
     command:
       type: array
     entrypoint:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -69,6 +69,29 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_0=.:/app
+  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_1=/var/run/docker.sock:/var/run/docker.sock
+  export BUILDKITE_COMMAND="echo hello world; pwd"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/app --volume /var/run/docker.sock:/var/run/docker.sock --workdir /app image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
+}
+
+@test "Runs BUILDKITE_COMMAND with deprecated mounts" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=.:/app
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"


### PR DESCRIPTION
This renames `mounts` to `volumes` to align with docker terminology. 

It's backwards compatible, so the older `mounts` will still work. 