### PR TITLE
Disable tty and mount-buildkite-agent for macos/windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Example: `/app`
 
 ### `mount-buildkite-agent` (optional)
 
-Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true`. Set to `false` if you want to disable, or if you already have your own binary in the image.
+Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Defaults to `true` for Linux, but `false` for macOS and Windows. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
 ### `volumes` (optional, array or bool)
 
@@ -106,6 +106,12 @@ Whether to always pull the latest image before running the command. Useful if th
 An array of additional environment variables to pass into to the docker container. Items can be specified as either `KEY` or `KEY=value`. Each entry corresponds to a Docker CLI `--env` parameter. Values specified as variable names will be passed through from the outer environment.
 
 Examples: `BUILDKITE_MESSAGE`, `MY_SECRET_KEY`, `MY_SPECIAL_BUT_PUBLIC_VALUE=kittens`
+
+### `tty` (optional)
+
+If set to false, doesn't allocate a TTY. This is useful in some situations where TTY's aren't supported, for instance windows.
+
+The default is `true` for linux or macOS, but `false` for windows.
 
 ### `user` (optional)
 

--- a/hooks/command
+++ b/hooks/command
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Reads a list from plugin config into a global result array
 # Returns success if values were read
-function plugin_read_list_into_result() {
+plugin_read_list_into_result() {
   result=()
 
   for prefix in "$@" ; do
@@ -38,16 +38,41 @@ expand_relative_volume_path() {
   fi
 }
 
+is_windows() {
+  [[ "$OSTYPE" =~ ^(win|msys|cygwin) ]]
+}
+
+is_macos() {
+  [[ "$OSTYPE" =~ ^(darwin) ]]
+}
+
 debug_mode='off'
 if [[ "${BUILDKITE_PLUGIN_DOCKER_DEBUG:-false}" =~ (true|on|1) ]] ; then
   echo "--- :hammer: Enabling debug mode"
   debug_mode='on'
 fi
 
-args=(
-  "-it"
-  "--rm"
-)
+tty_default='on'
+mount_agent_default='on'
+
+# Set operating system specific defaults
+if is_windows ; then
+  tty_default=''
+  mount_agent_default=''
+elif is_macos ; then
+  mount_agent_default=''
+fi
+
+args=()
+
+# Support switching tty off
+if [[ "${BUILDKITE_PLUGIN_DOCKER_TTY:-$tty_default}" =~ ^(true|on|1)$ ]] ; then
+  args+=("-it")
+else
+  args+=("-i")
+fi
+
+args+=("--rm")
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" =~ ^(true|false)$ ]] ; then
   echo -n "🚨 The Docker Plugin’s mounts configuration option must be an array or a boolean."
@@ -91,7 +116,7 @@ while IFS='=' read -r name _ ; do
 done < <(env | sort)
 
 # Handle the mount-buildkite-agent option
-if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-true}" =~ (true|on|1) ]] ; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-$mount_agent_default}" =~ ^(true|on|1)$ ]] ; then
   if [[ -z "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
     BUILDKITE_AGENT_BINARY_PATH=$(command -v buildkite-agent)
   fi
@@ -112,7 +137,7 @@ while IFS='=' read -r name _ ; do
   fi
 done < <(env | sort)
 
-if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ (true|on|1) ]] ; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
   docker pull "${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -54,11 +54,15 @@ fi
 
 tty_default='on'
 mount_agent_default='on'
+pwd_default="$PWD"
+workdir_default="/workdir"
 
 # Set operating system specific defaults
 if is_windows ; then
   tty_default=''
   mount_agent_default=''
+  workdir_default="C:\\workdir"
+  pwd_default="$(cmd.exe /C "echo %CD%")"
 elif is_macos ; then
   mount_agent_default=''
 fi
@@ -75,12 +79,12 @@ fi
 args+=("--rm")
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" =~ ^(true|false)$ ]] ; then
-  echo -n "🚨 The Docker Plugin’s mounts configuration option must be an array or a boolean."
+  echo "🚨 The Docker Plugin’s mounts configuration option must be an array or a boolean."
   exit 1
 fi
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" =~ ^(true|false)$ ]] ; then
-  echo -n "🚨 The Docker Plugin’s volumes configuration option must be an array or a boolean."
+  echo "🚨 The Docker Plugin’s volumes configuration option must be an array or a boolean."
   exit 1
 fi
 
@@ -95,12 +99,12 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN
 
 # By default, mount $PWD onto $WORKDIR
 elif [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" != "false  " ]] ; then
-  args+=( "--volume" "$PWD:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}" )
+  args+=( "--volume" "${pwd_default}:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}" )
 fi
 
 # Set workdir if one is provided or if mounts is the default
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ -n "$default_volumes" ]]; then
-  args+=("--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-/workdir}")
+  args+=("--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}")
 fi
 
 # Support docker run --user
@@ -118,9 +122,17 @@ done < <(env | sort)
 # Handle the mount-buildkite-agent option
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-$mount_agent_default}" =~ ^(true|on|1)$ ]] ; then
   if [[ -z "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
-    BUILDKITE_AGENT_BINARY_PATH=$(command -v buildkite-agent)
+    if ! command -v buildkite-agent >/dev/null 2>&1 ; then
+      echo -n "+++ 🚨 Failed to find buildkite-agent in PATH to mount into container, "
+      echo "you can disable this behaviour with 'mount-buildkite-agent:false'"
+    else
+      BUILDKITE_AGENT_BINARY_PATH=$(command -v buildkite-agent)
+    fi
   fi
+fi
 
+# Mount buildkite-agent if we have a path for it
+if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
   args+=(
     "--env" "BUILDKITE_JOB_ID"
     "--env" "BUILDKITE_BUILD_ID"
@@ -199,7 +211,11 @@ args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
 
 # Set a default shell if one is needed
 if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
-  shell=("/bin/sh" "-e" "-c")
+  if is_windows ; then
+    shell=("CMD.EXE" "/c")
+  else
+    shell=("/bin/sh" "-e" "-c")
+  fi
 fi
 
 command=()


### PR DESCRIPTION
This is one of the last breaking changes I want to make before 2.0.0. Currently if you run this plugin on windows or mac, you get errors by default due to the lack of tty on windows and the inability to mount `/usr/local/bin/buildkite-agent` with Docker for Mac or Docker for Windows. On windows, you also get errors because windows paths are needed for volume mounts. 

This adds a layer of operating system detection that can change the defaults for things. You can still opt to turn those features on manually, but out of the box you get defaults that work for mac/windows. 

Thoughts @toolmantim? 