### PR TITLE
Clean up options and update the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,56 +90,15 @@ steps:
 
 ## Configuration
 
+### Required
+
 ### `image` (required, string)
 
 The name of the Docker image to use.
 
 Example: `node:7`
 
-### `workdir`(optional, string)
-
-The working directory to run the command in, inside the container. The default is `/workdir`.
-
-Example: `/app`
-
-### `mount-buildkite-agent` (optional, boolean)
-
-Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Set to `false` if you want to disable, or if you already have your own binary in the image.
-
-Default: `true` for Linux, and `false` for macOS and Windows.
-
-### `volumes` (optional, array or boolean)
-
-Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter. Relative local paths are converted to their full-path (e.g `.:/app`).
-
-To disable the default mount mounts, set `volumes` to `false`.
-
-Default: `true`
-Example: `[ ".:/app", "/var/run/docker.sock:/var/run/docker.sock" ]`
-
-### `always-pull` (optional, boolean)
-
-Whether to always pull the latest image before running the command. Useful if the image has a `latest` tag.
-
-Default: `false`
-
-### `environment` (optional, array)
-
-An array of additional environment variables to pass into to the docker container. Items can be specified as either `KEY` or `KEY=value`. Each entry corresponds to a Docker CLI `--env` parameter. Values specified as variable names will be passed through from the outer environment.
-
-Example: `[ "BUILDKITE_MESSAGE", "MY_SECRET_KEY", "MY_SPECIAL_BUT_PUBLIC_VALUE=kittens" ]`
-
-### `tty` (optional, boolean)
-
-If set to false, doesn't allocate a TTY. This is useful in some situations where TTY's aren't supported, for instance windows.
-
-Default: `true` for Linux and macOS, and `false` for Windows.
-
-### `user` (optional, string)
-
-Allows a user to be set, and override the USER entry in the Dockerfile. See https://docs.docker.com/engine/reference/run/#user for more details.
-
-Example: `root`
+### Optional
 
 ### `additional-groups` (optional, array)
 
@@ -147,17 +106,49 @@ Additional groups to be added to the user in the container, in an array of group
 
 Example: `docker`
 
-### `network` (optional, string)
+### `always-pull` (optional, boolean)
 
-Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details.
+Whether to always pull the latest image before running the command. Useful if the image has a `latest` tag.
 
-Example: `test-network`
+Default: `false`
+
+### `command` (optional, array)
+
+Sets the command for the Docker image, and defaults the `shell` option to `false`. Useful if the Docker image has an entrypoint, or doesn't contain a shell.
+
+This option can't be used if your step already has a top-level, non-plugin `command` option present.
+
+Examples: `[ "/bin/mycommand", "-c", "test" ]`, `["arg1", "arg2"]`
 
 ### `debug` (optional, boolean)
 
 Enables debug mode, which outputs the full Docker commands that will be run on the agent machine.
 
 Default: `false`
+
+### `entrypoint` (optional, string)
+
+Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details.
+
+Example: `/my/custom/entrypoint.sh`
+
+### `environment` (optional, array)
+
+An array of additional environment variables to pass into to the docker container. Items can be specified as either `KEY` or `KEY=value`. Each entry corresponds to a Docker CLI `--env` parameter. Values specified as variable names will be passed through from the outer environment.
+
+Example: `[ "BUILDKITE_MESSAGE", "MY_SECRET_KEY", "MY_SPECIAL_BUT_PUBLIC_VALUE=kittens" ]`
+
+### `mount-buildkite-agent` (optional, boolean)
+
+Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Set to `false` if you want to disable, or if you already have your own binary in the image.
+
+Default: `true` for Linux, and `false` for macOS and Windows.
+
+### `network` (optional, string)
+
+Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details.
+
+Example: `test-network`
 
 ### `runtime` (optional, string)
 
@@ -171,19 +162,32 @@ Set the shell to use for the command. Set it to `false` to pass the command dire
 
 Example: `[ "powershell", "-Command" ]`
 
-### `entrypoint` (optional, string)
+### `tty` (optional, boolean)
 
-Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details.
+If set to false, doesn't allocate a TTY. This is useful in some situations where TTY's aren't supported, for instance windows.
 
-Example: `/my/custom/entrypoint.sh`
+Default: `true` for Linux and macOS, and `false` for Windows.
 
-### `command` (optional, array)
+### `user` (optional, string)
 
-Sets the command for the Docker image, and defaults the `shell` option to `false`. Useful if the Docker image has an entrypoint, or doesn't contain a shell.
+Allows a user to be set, and override the USER entry in the Dockerfile. See https://docs.docker.com/engine/reference/run/#user for more details.
 
-This option can't be used if your step already has a top-level, non-plugin `command` option present.
+Example: `root`
 
-Examples: `[ "/bin/mycommand", "-c", "test" ]`, `["arg1", "arg2"]`
+### `volumes` (optional, array or boolean)
+
+Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter. Relative local paths are converted to their full-path (e.g `.:/app`).
+
+To disable the default mount mounts, set `volumes` to `false`.
+
+Default: `true`
+Example: `[ ".:/app", "/var/run/docker.sock:/var/run/docker.sock" ]`
+
+### `workdir`(optional, string)
+
+The working directory to run the command in, inside the container. The default is `/workdir`.
+
+Example: `/app`
 
 ## License
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,36 +5,36 @@ requirements:
   - docker
 configuration:
   properties:
-    image:
-      type: string
-    workdir:
-      type: string
+    additional-groups:
+      type: array
     always-pull:
-      type: string
-    mount-buildkite-agent:
       type: boolean
-    mounts:
-      type: [boolean,array]
-    volumes:
-      type: [boolean,array]
     command:
       type: array
+    debug:
+      type: boolean
     entrypoint:
       type: string
     environment:
       type: array
-    user:
+    image:
       type: string
-    additional_groups:
-      type: array
+    mount-buildkite-agent:
+      type: boolean
     network:
       type: string
-    debug:
-      type: boolean
     runtime:
       type: string
     shell:
       type: [boolean, array]
+    tty:
+      type: boolean
+    user:
+      type: string
+    volumes:
+      type: [boolean, array]
+    workdir:
+      type: string
   required:
     - image
   additionalProperties: false


### PR DESCRIPTION
Splits up the configuration options into required and optional, and fixes the `always-pull` schema to be a boolean instead of a string.