### PR TITLE
Adds an option for propagating the environment to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ steps:
             - "MY_SPECIAL_BUT_PUBLIC_VALUE=kittens"
 ```
 
+Environment variables available in the step can also automatically be propagated to the container:
+
+```yml
+steps:
+  - command:
+      - "yarn install"
+      - "yarn run test"
+    env:
+      MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
+    plugins:
+      - docker#v2.0.0:
+          image: "node:7"
+          always-pull: true
+          workdir: "/app"
+          volumes:
+            - "./code:/app"
+          propagate-environment: true
+```
+
 You can pass in additional volumes to be mounted. This disables the default mount behaviour of mounting `$PWD` to `/workdir`. This is useful for running Docker :
 
 ```yml
@@ -137,6 +156,12 @@ Example: `/my/custom/entrypoint.sh`
 An array of additional environment variables to pass into to the docker container. Items can be specified as either `KEY` or `KEY=value`. Each entry corresponds to a Docker CLI `--env` parameter. Values specified as variable names will be passed through from the outer environment.
 
 Example: `[ "BUILDKITE_MESSAGE", "MY_SECRET_KEY", "MY_SPECIAL_BUT_PUBLIC_VALUE=kittens" ]`
+
+### `propagate-environment` (optional, boolean)
+
+Whether or not to automatically propagate all pipeline environment variables into the docker container. Avoiding the need to be specified with `environment`.
+
+Note that all Buildkite and pipeline environment variables will be propagated, this includes any secrets that may be in an environment variable.
 
 ### `mount-buildkite-agent` (optional, boolean)
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Example: `[ "BUILDKITE_MESSAGE", "MY_SECRET_KEY", "MY_SPECIAL_BUT_PUBLIC_VALUE=k
 
 Whether or not to automatically propagate all pipeline environment variables into the docker container. Avoiding the need to be specified with `environment`.
 
-Note that all Buildkite and pipeline environment variables will be propagated, this includes any secrets that may be in an environment variable.
+Note that only pipeline variables will automatically be propagated (what you see in the Buildkite UI). Variables set in proceeding hook scripts will not be propagated to the container.
 
 ### `mount-buildkite-agent` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -158,6 +158,15 @@ while IFS='=' read -r name _ ; do
   fi
 done < <(env | sort)
 
+# Propagate all environment variables into the container if requested
+if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT:-false}" =~ ^(true|on|1)$ ]] ; then
+  if [[ -n "${BUILDKITE_ENV_FILE:-}" ]] ; then
+    args+=( "--env-file" "${BUILDKITE_ENV_FILE:-}" )
+  else
+    echo -n "🚨 Not propagating environment variables to container as \$BUILDKITE_ENV_FILE is not set"
+  fi
+fi
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
   docker pull "${BUILDKITE_PLUGIN_DOCKER_IMAGE}"

--- a/hooks/command
+++ b/hooks/command
@@ -161,7 +161,12 @@ done < <(env | sort)
 # Propagate all environment variables into the container if requested
 if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT:-false}" =~ ^(true|on|1)$ ]] ; then
   if [[ -n "${BUILDKITE_ENV_FILE:-}" ]] ; then
-    args+=( "--env-file" "${BUILDKITE_ENV_FILE:-}" )
+    # Read in the env file and convert to --env params for docker
+    # This is because --env-file doesn't support newlines or quotes per https://docs.docker.com/compose/env-file/#syntax-rules
+    while read -r var; do
+      echo "${var%%=*}"
+      args+=( --env "${var%%=*}" )
+    done < "$BUILDKITE_ENV_FILE"
   else
     echo -n "🚨 Not propagating environment variables to container as \$BUILDKITE_ENV_FILE is not set"
   fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,6 +35,8 @@ configuration:
       type: [boolean, array]
     workdir:
       type: string
+    propagate-environment:
+      type: boolean
   required:
     - image
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -180,8 +180,13 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_ENV_FILE="/tmp/amazing"
 
+  cat << EOF > $BUILDKITE_ENV_FILE
+FOO="BAR"
+A_VARIABLE="with\nnewline"
+EOF
+
   stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env-file /tmp/amazing image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env FOO --env A_VARIABLE image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -172,6 +172,29 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
+@test "Runs BUILDKITE_COMMAND with propagate environment" {
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT=true
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_ENV_FILE="/tmp/amazing"
+
+  stub docker \
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env-file /tmp/amazing image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT
+  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
+}
+
 @test "Runs BUILDKITE_COMMAND with user" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false


### PR DESCRIPTION
This closes #79 by adding a `propagate-environment` variable that exposes `$BUILDKITE_ENV_FILE` to the container (via `--envfile`)

The `$BUILDKITE_ENV_FILE` is the environment variables for the step, e.g. won't include `$PATH`, `$PWD` and other variables that may break/confuse the docker container.