### PR TITLE
Add mount-ssh-agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ Whether to automatically mount the `buildkite-agent` binary from the host agent 
 
 Default: `true` for Linux, and `false` for macOS and Windows.
 
+### `mount-ssh-agent` (optional, boolean)
+
+Whether to automatically mount the ssh-agent socket from the host agent machine into the container (at `/ssh-agent`and `/root/.ssh/known_hosts` respectively), allowing git operations to work correctly.
+
+Default: `false`
+
 ### `network` (optional, string)
 
 Join the container to the docker network specified. The network will be created if it does not already exist. See https://docs.docker.com/engine/reference/run/#network-settings for more details.

--- a/hooks/command
+++ b/hooks/command
@@ -54,6 +54,7 @@ fi
 
 tty_default='on'
 mount_agent_default='on'
+mount_ssh_agent=''
 pwd_default="$PWD"
 workdir_default="/workdir"
 
@@ -127,6 +128,15 @@ while IFS='=' read -r name _ ; do
     args+=( "--group-add" "${!name}" )
   fi
 done < <(env | sort)
+
+# Mount ssh-agent socket and known_hosts
+if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|on|1)$ ]] ; then
+  args+=(
+    "--env" "SSH_AUTH_SOCK=/ssh-agent"
+    "--volume" "${SSH_AUTH_SOCK}:/ssh-agent"
+    "--volume" "${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts"
+  )
+fi
 
 # Handle the mount-buildkite-agent option
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-$mount_agent_default}" =~ ^(true|on|1)$ ]] ; then


### PR DESCRIPTION
I couldn't find any way of using git inside a docker container with the current plugin setup.

This adds a new option `mount-ssh-agent` (defaults to false) which mounts the ssh-agent in the container at `/ssh-agent` and sets the `SSH_AUTH_SOCK` environment variable. It also mounts `known_hosts`.

My initial attempt to do this using the stock plugin failed because `volumes` are only parsed at pipeline upload time and the ssh-agent socket changes from step to step. So this:
```
- label: 'Build'
  command:
    - ./build.sh
  plugins:
    docker#2.1.0:
      image: 'node:8'
      volumes:
      - .:/workdir
      - ${SSH_AUTH_SOCK}:/ssh-agent
      - ${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts
      workdir: /workdir
      environment:
      - SSH_AUTH_SOCK=/ssh-agent
```
results in and invalid socket path being mounted.

Trying to work around this using pre-command hooks also proved fruitless.