### PR TITLE
Add ability to configure size of /dev/shm for running docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Set the shell to use for the command. Set it to `false` to pass the command dire
 
 Example: `[ "powershell", "-Command" ]`
 
+### `shm-size` (optional, string)
+
+Set the size of the `/dev/shm` shared memory filesystem mount inside the docker contianer. If unset, uses the default for the platform (typically `64mb`). See https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources for information on allowed formats.
+
+Example: `2gb`
+
 ### `tty` (optional, boolean)
 
 If set to false, doesn't allocate a TTY. This is useful in some situations where TTY's aren't supported, for instance windows.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Example: `[ "powershell", "-Command" ]`
 
 ### `shm-size` (optional, string)
 
-Set the size of the `/dev/shm` shared memory filesystem mount inside the docker contianer. If unset, uses the default for the platform (typically `64mb`). See https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources for information on allowed formats.
+Set the size of the `/dev/shm` shared memory filesystem mount inside the docker contianer. If unset, uses the default for the platform (typically `64mb`). See [docker run’s runtime constraints documentation](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources) for information on allowed formats.
 
 Example: `2gb`
 

--- a/hooks/command
+++ b/hooks/command
@@ -206,6 +206,11 @@ if [[ -n "${BUILDKITE_COMMAND}" ]]; then
   shell_disabled=''
 fi
 
+# Handle setting of shm size if provided
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SHM_SIZE}" ]]; then
+  args+=("--shm-size" "${BUILDKITE_PLUGIN_DOCKER_SHM_SIZE}")
+fi
+
 # Handle entrypoint if provided, and default shell to disabled
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}" ]] ; then
   args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}")

--- a/hooks/command
+++ b/hooks/command
@@ -207,7 +207,7 @@ if [[ -n "${BUILDKITE_COMMAND}" ]]; then
 fi
 
 # Handle setting of shm size if provided
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SHM_SIZE}" ]]; then
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SHM_SIZE:-}" ]]; then
   args+=("--shm-size" "${BUILDKITE_PLUGIN_DOCKER_SHM_SIZE}")
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -27,6 +27,8 @@ configuration:
       type: string
     shell:
       type: [boolean, array]
+    shm-size:
+      type: string
     tty:
       type: boolean
     user:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -179,7 +179,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND="df --block-size=1 /dev/shm | awk '{print $2}' | tail -n1"
 
   stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --shm-size=100mb image:tag /bin/sh -e -c 'df --block-size=1 /dev/shm | awk '{print $2}' | tail -n1' : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --shm-size=100mb image:tag /bin/sh -e -c \"df --block-size=1 /dev/shm | awk '{print \\\$2}' | tail -n1\" : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -176,15 +176,15 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHM_SIZE=100mb
-  export BUILDKITE_COMMAND="df --block-size=1 /dev/shm | awk '{print $2}' | tail -n1"
+  export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --volume $PWD:/workdir --workdir /workdir --shm-size=100mb image:tag /bin/sh -e -c \"df --block-size=1 /dev/shm | awk '{print \\\$2}' | tail -n1\" : echo ran command in docker"
+    "run -it --rm --volume $PWD:/workdir --workdir /workdir --shm-size 100mb image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial "104857600"
+  assert_output --partial "ran command in docker"
 
   unstub docker
   unset BUILDKITE_PLUGIN_DOCKER_IMAGE


### PR DESCRIPTION
- add `shm-size` plugin setting
  - takes string which is then passed as `docker run --shm-size <string>`