### PR TITLE
Add a mount-checkout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ See [Docker's documentation](https://docs.docker.com/engine/reference/run/#speci
 
 Default: `true` for Linux and macOS, `false` for Windows.
 
+### `mount-checkout` (optional, boolean)
+
+Whether to automatically mount the current working directory which contains your checked out codebase. Mounts onto `/workdir`, unless `workdir` is set, in which case that will be used.
+
+Default: `true`
+
 ### `mount-buildkite-agent` (optional, boolean)
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Set to `false` if you want to disable, or if you already have your own binary in the image.

--- a/hooks/command
+++ b/hooks/command
@@ -96,13 +96,6 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_
   exit 1
 fi
 
-# Parse volumes (and deprecated mounts) and add them to the docker args
-if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
-  for arg in "${result[@]}" ; do
-    args+=( "--volume" "$(expand_relative_volume_path "${arg}")" )
-  done
-fi
-
 # Parse tmpfs property.
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_TMPFS ; then
   for arg in "${result[@]}" ; do
@@ -112,15 +105,25 @@ fi
 
 workdir=''
 
-# Set workdir if one is provided or if the checkout is mounted
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
   workdir="${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}"
-  args+=("--workdir" "${workdir}")
 fi
 
 # By default, mount $PWD onto $WORKDIR
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
   args+=( "--volume" "${pwd_default}:${workdir}" )
+fi
+
+# Parse volumes (and deprecated mounts) and add them to the docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
+  for arg in "${result[@]}" ; do
+    args+=( "--volume" "$(expand_relative_volume_path "${arg}")" )
+  done
+fi
+
+# Set workdir if one is provided or if the checkout is mounted
+if [[ -n "${workdir:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]]; then
+  args+=("--workdir" "${workdir}")
 fi
 
 # Support docker run --user

--- a/hooks/command
+++ b/hooks/command
@@ -96,19 +96,8 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_
   exit 1
 fi
 
-default_volumes=1
-
-# Handle volumes=true (meaning defaults), otherwise we get an error about it not being an array
-if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" == "true" || "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" == "true" ]] ; then
-  :
-
-# Handle volumes=false (meaning no volumes)
-elif [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" == "false" || "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" == "false" ]] ; then
-  default_volumes=''
-
 # Parse volumes (and deprecated mounts) and add them to the docker args
-elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
-  default_volumes=''
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
   for arg in "${result[@]}" ; do
     args+=( "--volume" "$(expand_relative_volume_path "${arg}")" )
   done
@@ -121,14 +110,17 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_TMPFS ; then
   done
 fi
 
-# By default, mount $PWD onto $WORKDIR
-if [[ -n "$default_volumes" ]] ; then
-  args+=( "--volume" "${pwd_default}:${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}" )
+workdir=''
+
+# Set workdir if one is provided or if the checkout is mounted
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
+  workdir="${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}"
+  args+=("--workdir" "${workdir}")
 fi
 
-# Set workdir if one is provided or if mounts is the default
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ -n "$default_volumes" ]]; then
-  args+=("--workdir" "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}")
+# By default, mount $PWD onto $WORKDIR
+if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
+  args+=( "--volume" "${pwd_default}:${workdir}" )
 fi
 
 # Support docker run --user

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -69,8 +69,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_0=.:/app
-  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_1=/var/run/docker.sock:/var/run/docker.sock
+  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_0=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
@@ -88,10 +87,10 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
-@test "Runs BUILDKITE_COMMAND with volumes=false and no workdir" {
+@test "Runs BUILDKITE_COMMAND with mount-checkout=false" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_VOLUMES=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT=false
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
@@ -107,11 +106,11 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_COMMAND
 }
 
-@test "Runs BUILDKITE_COMMAND with volumes=true" {
+@test "Runs BUILDKITE_COMMAND with mount-checkout=true" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT=true
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_VOLUMES=true
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
@@ -131,8 +130,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=.:/app
-  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_1=/var/run/docker.sock:/var/run/docker.sock
+  export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \


### PR DESCRIPTION
In v2.0.0 we made a slightly weird change where by if you specified volumes that you wanted mounted, it would not mount the checkout directory into the container on the assumption that you would do it yourself. We also allowed a confusing value of `volumes: false` to disable the "default mounts", e.g the checkout directory.

This PR tries to unwind some of that complexity. Whether to mount the checkout dir into the container is determined by `mount-checkout`, which defaults to `true`. It will mount onto whatever you set for `workdir`. If you don't want this behaviour, you set `mount-checkout` to `false`. `volumes: false` is no longer a thing.