### PR TITLE
Add propagate-uid-gid option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Whether or not to automatically propagate all pipeline environment variables int
 
 Note that only pipeline variables will automatically be propagated (what you see in the Buildkite UI). Variables set in proceeding hook scripts will not be propagated to the container.
 
+### `propagate-uid-gid` (optional, boolean)
+
+Whether to match the user ID and group ID for the container user to the user ID and group ID for the host user. It is similar to specifying `user: 1000:1000`, except it avoids hardcoding a particular user/group ID.
+
+Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that Buildkite will be unable to remove, since containers by default run as the root user.
+
 ### `privileged` (optional, boolean)
 
 Whether or not to run the container in [privileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)

--- a/hooks/command
+++ b/hooks/command
@@ -149,8 +149,17 @@ if [[ -n "${workdir:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}"
 fi
 
 # Support docker run --user
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USER:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_UID_GID:-}" ]]; then
+  echo "+++ Error: Can't set both user and propagate-uid-gid"
+  exit 1
+fi
+
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USER:-}" ]] ; then
   args+=("-u" "${BUILDKITE_PLUGIN_DOCKER_USER:-}")
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_UID_GID:-}" ]] ; then
+  args+=("-u" "$(id -u):$(id -g)")
 fi
 
 # Support docker run --group-add

--- a/plugin.yml
+++ b/plugin.yml
@@ -45,6 +45,8 @@ configuration:
       type: string
     propagate-environment:
       type: boolean
+    propagate-uid-gid:
+      type: boolean
     privileged:
       type: boolean
     init:


### PR DESCRIPTION
Add an option, `propagate-uid-gid`, to match the container UID/GID to
the host UID/GID. This avoids littering shared mounts with root-owned
files. The existing `user` option isn't quite flexible enough, as it
requires you to know the name of the user you want to run as, and often
you just want to use whatever UID/GID the host agent happens to be
running as.