### PR TITLE
Beautify the "Running command [...]" message.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -352,11 +352,11 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-echo "--- :docker: Running ${display_command[*]} in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+echo "--- :docker: Logging \"docker run\" command"
+echo "$ docker run ${args[*]}" >&2
 
-if [[ "${debug_mode:-off}" =~ (on) ]] ; then
-  echo "$ docker run ${args[*]}" >&2
-fi
+echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+echo "$ ${display_command[*]}" >&2
 
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.

--- a/hooks/command
+++ b/hooks/command
@@ -352,8 +352,10 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-echo "--- :docker: Logging \"docker run\" command"
-echo "$ docker run ${args[*]}" >&2
+if [[ "${debug_mode:-off}" =~ (on) ]] ; then
+  echo "--- :docker: Logging \"docker run\" command"
+  echo "$ docker run ${args[*]}" >&2
+fi
 
 echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 echo "$ ${display_command[*]}" >&2

--- a/hooks/command
+++ b/hooks/command
@@ -352,10 +352,8 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-if [[ "${debug_mode:-off}" =~ (on) ]] ; then
-  echo "--- :docker: Logging \"docker run\" command"
-  echo "$ docker run ${args[*]}" >&2
-fi
+echo "--- :docker: Logging \"docker run\" command"
+echo "$ docker run ${args[*]}" >&2
 
 echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 echo "$ ${display_command[*]}" >&2


### PR DESCRIPTION
The plug-in currently prints two messages that help with figuring out what it is actually running:
1) It always prints a "Running $command in $image" message.
2) In debug mode, it additionally prints the "docker run" command line, too.

There are two little problems with these messages:
1) If $command is very long, you get a very long group header (that also somehow sometimes doesn't quote the command correctly). It also gets messy when the command has multiple lines, because only the first line is printed as the group header, the rest then follows in the collapsed body.
2) The docker run command is printed without any context below the already printed command-line, which makes it a bit hard to understand what's going on.

The fixed version puts both messages in their own collapsed groups, which (IMHO) looks much nicer and also makes it easier to copy & paste them.

Before:
<img width="1071" alt="Screenshot 2019-04-15 at 17 08 12" src="https://user-images.githubusercontent.com/504652/56143570-12207080-5fa1-11e9-8951-1e20c9150f60.png">
<img width="1063" alt="Screenshot 2019-04-15 at 17 05 49" src="https://user-images.githubusercontent.com/504652/56143599-1ba9d880-5fa1-11e9-9bcd-f62afca62da0.png">

After:
<img width="1076" alt="Screenshot 2019-04-15 at 17 06 10" src="https://user-images.githubusercontent.com/504652/56143617-1f3d5f80-5fa1-11e9-855c-f463572d81f0.png">
<img width="1081" alt="Screenshot 2019-04-15 at 17 06 21" src="https://user-images.githubusercontent.com/504652/56143621-21072300-5fa1-11e9-8507-2584e5fae3fc.png">
