### PR TITLE
Document mounting docker repo credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ steps:
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
 ```
+* Note that to push/pull docker images within your step container, you'll additionally need to mount `~/.docker/config.json` – with the associated security implications.
 
 You can disable the default behaviour of mounting in the checkout to `workdir`:
 


### PR DESCRIPTION
Otherwise if you want to push/pull images from remote docker repositories from within your step container it won't work.

For the Elastic Stack, the credentials on the host live at `/var/lib/buildkite-agent/.docker/config.json`