### PR TITLE
Add docker sysctl support

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -143,6 +143,19 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN
   done
 fi
 
+# Ensure sysctl option is an array
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SYSCTLS:-}" ]] ; then
+  echo -n "🚨 The Docker Plugin’s sysctl configuration option must be an array."
+  exit 1
+fi
+
+# Parse sysctl args and add them to docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SYSCTLS ; then
+  for arg in "${result[@]}" ; do
+    args+=( "--sysctl" "$arg" )
+  done
+fi
+
 # Set workdir if one is provided or if the checkout is mounted
 if [[ -n "${workdir:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]]; then
   args+=("--workdir" "${workdir}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -51,6 +51,8 @@ configuration:
       type: boolean
     init:
       type: boolean
+    sysctls:
+      type: array
   required:
     - image
   additionalProperties: false


### PR DESCRIPTION
Docker run has a sysctl option to specify kernel parameters in the container. This PR adds support for sysctl to the buildkite plugin. More information about this option can be found here: https://docs.docker.com/engine/reference/commandline/run/