### PR TITLE
Cleanup any remaining containers in a pre-exit 

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -euo pipefail
 
 # retry <number-of-retries> <command>
@@ -296,6 +295,9 @@ elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SHELL ; then
     shell+=("$arg")
   done
 fi
+
+# Add the job id as meta-data for reference in pre-exit
+args+=("--label" "com.buildkite.job-id=${BUILDKITE_JOB_ID}")
 
 # Add the image in before the shell and command
 args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,11 +1,10 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
   for container in $(docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}") ; do
     echo "~~~ Cleaning up left-over container ${container}"
     docker stop "$container"
-    docker rm -v -f "$container"
   done
 fi
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,8 +1,9 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
   for container in $(docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}") ; do
+    echo "~~~ Cleaning up left-over container ${container}"
     docker stop "$container"
     docker rm -v -f "$container"
   done

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,4 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}"
+if [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
+  for container in $(docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}") ; do
+    docker stop "$container"
+    docker rm -v -f "$container"
+  done
+fi
+

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -38,15 +38,13 @@ setup() {
   stub docker \
     "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker" \
     "ps -a -q --filter label=com.buildkite.job-id=1-2-3-4 : echo 939fb4ab31b2" \
-    "stop 939fb4ab31b2 : echo stopped container" \
-    "rm -v -f 939fb4ab31b2 : echo removed container"
+    "stop 939fb4ab31b2 : echo stopped container"
 
   run bash -c "$PWD/hooks/command && $PWD/hooks/pre-exit"
 
   assert_success
   assert_output --partial "ran command in docker"
   assert_output --partial "stopped container"
-  assert_output --partial "removed container"
 
   unstub docker
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -5,13 +5,21 @@ load '/usr/local/lib/bats/load.bash'
 # Uncomment to enable stub debug output:
 # export DOCKER_STUB_DEBUG=/dev/tty
 
-@test "Run with BUILDKITE_COMMAND" {
+setup() {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_JOB_ID="1-2-3-4"
+  export BUILDKITE_PLUGIN_DOCKER_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_COMMAND="pwd"
+}
+
+@test "Run with BUILDKITE_COMMAND" {
   export BUILDKITE_COMMAND='command1 "a string"'
   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -19,19 +27,36 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
+}
+
+@test "Run with BUILDKITE_COMMAND and cleanup remaining containers" {
+  export BUILDKITE_COMMAND='command1 "a string"'
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+  unset BUILDKITE_PLUGIN_DOCKER_CLEANUP
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker" \
+    "ps -a -q --filter label=com.buildkite.job-id=1-2-3-4 : echo 939fb4ab31b2" \
+    "stop 939fb4ab31b2 : echo stopped container" \
+    "rm -v -f 939fb4ab31b2 : echo removed container"
+
+  run bash -c "$PWD/hooks/command && $PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial "ran command in docker"
+  assert_output --partial "stopped container"
+  assert_output --partial "removed container"
+
+  unstub docker
 }
 
 @test "Pull image first before running BUILDKITE_COMMAND with mount-buildkite-agent disabled" {
   export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_COMMAND="pwd"
 
   stub docker \
     "pull image:tag : echo pulled latest image" \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -40,19 +65,14 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 }
 
 @test "Runs BUILDKITE_COMMAND with mount-buildkite-agent disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -60,20 +80,15 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
 }
 
 @test "Runs BUILDKITE_COMMAND with volumes" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_VOLUMES_0=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/app --volume /var/run/docker.sock:/var/run/docker.sock --workdir /app image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/app --volume /var/run/docker.sock:/var/run/docker.sock --workdir /app --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -81,22 +96,16 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
 @test "Runs BUILDKITE_COMMAND with sysctls" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SYSCTLS_0=net.ipv4.ip_forward=1
   export BUILDKITE_PLUGIN_DOCKER_SYSCTLS_1=net.unix.max_dgram_qlen=200
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/app --sysctl net.ipv4.ip_forward=1 --sysctl net.unix.max_dgram_qlen=200 --workdir /app image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/app --sysctl net.ipv4.ip_forward=1 --sysctl net.unix.max_dgram_qlen=200 --workdir /app --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -104,20 +113,14 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
 @test "Runs BUILDKITE_COMMAND with mount-checkout=false" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT=false
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --init image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --init --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -125,19 +128,15 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs BUILDKITE_COMMAND with mount-checkout=true" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT=true
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/app --workdir /app image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/app --workdir /app --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -145,19 +144,16 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs BUILDKITE_COMMAND with deprecated mounts" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_MOUNTS_0=/var/run/docker.sock:/var/run/docker.sock
   export BUILDKITE_COMMAND="echo hello world; pwd"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/app --volume /var/run/docker.sock:/var/run/docker.sock --workdir /app image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/app --volume /var/run/docker.sock:/var/run/docker.sock --workdir /app --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -165,21 +161,15 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
 @test "Runs BUILDKITE_COMMAND with environment" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=ANOTHER_TAG=llamas
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env ANOTHER_TAG=llamas image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env ANOTHER_TAG=llamas --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -187,20 +177,14 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1
 }
 
 @test "Runs BUILDKITE_COMMAND with shm size" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHM_SIZE=100mb
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --shm-size 100mb image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --shm-size 100mb --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -208,14 +192,9 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_SHM_SIZE
 }
 
 @test "Runs BUILDKITE_COMMAND with propagate environment" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT=true
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
   export BUILDKITE_COMMAND="echo hello world"
@@ -227,7 +206,7 @@ A_VARIABLE="with\nnewline"
 EOF
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env FOO --env A_VARIABLE image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env MY_TAG=value --env FOO --env A_VARIABLE --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -235,20 +214,14 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT
-  unset BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0
 }
 
 @test "Runs BUILDKITE_COMMAND with user" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_USER=foo
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir -u foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir -u foo --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -256,20 +229,15 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
 @test "Runs BUILDKITE_COMMAND with additional groups" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --group-add foo --group-add bar image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --group-add foo --group-add bar --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -277,15 +245,9 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0
-  unset BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1
 }
 
 @test "Runs BUILDKITE_COMMAND with propagated uid and guid" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_PROPAGATE_UID_GID=true
   export BUILDKITE_COMMAND="echo hello world"
 
@@ -294,7 +256,7 @@ EOF
     "-g : echo 456"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir -u 123:456 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir -u 123:456 --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -303,21 +265,16 @@ EOF
 
   unstub id
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_USER
 }
 
 @test "Runs BUILDKITE_COMMAND with network that doesn't exist" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_NETWORK=foo
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
     "network ls --quiet --filter 'name=foo' : echo " \
     "network create foo : echo creating network foo" \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --network foo image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --network foo --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -326,19 +283,14 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_DOCKER_NETWORK
 }
 
 @test "Runs BUILDKITE_COMMAND with custom runtime" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_RUNTIME=custom_runtime
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --runtime custom_runtime image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --runtime custom_runtime --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -346,20 +298,14 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_RUNTIME
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs BUILDKITE_COMMAND with entrypoint without explicit shell" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point --label com.buildkite.job-id=1-2-3-4 image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -367,15 +313,9 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs BUILDKITE_COMMAND with entrypoint with explicit shell" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=/some/custom/entry/point
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
   export BUILDKITE_PLUGIN_DOCKER_SHELL_1='-a'
@@ -383,7 +323,7 @@ EOF
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint /some/custom/entry/point --label com.buildkite.job-id=1-2-3-4 image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -391,11 +331,6 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 # Unfortunately trying to match an empty string argument with bats-mock is impossible:
@@ -438,15 +373,13 @@ EOF
 # }
 
 @test "Runs BUILDKITE_COMMAND with shell" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
   export BUILDKITE_PLUGIN_DOCKER_SHELL_1='-a'
   export BUILDKITE_PLUGIN_DOCKER_SHELL_2='-b'
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag custom-bash -a -b 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -454,15 +387,9 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs BUILDKITE_COMMAND with shell option as string" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL='custom-bash -a -b'
   export BUILDKITE_COMMAND="echo hello world"
 
@@ -470,21 +397,14 @@ EOF
 
   assert_failure
   assert_output --partial "shell configuration option can no longer be specified as a string, but only as an array"
-
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs BUILDKITE_COMMAND with shell disabled" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_SHELL=false
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -492,15 +412,9 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs with a command as a string" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND="echo hello world"
   export BUILDKITE_COMMAND=
 
@@ -508,22 +422,15 @@ EOF
 
   assert_failure
   assert_output --partial "command configuration option must be an array"
-
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs with a command as an array" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_1="hello world"
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag echo 'hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -531,15 +438,9 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs with a command as an array with a shell" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_1="hello world"
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
@@ -548,7 +449,7 @@ EOF
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -556,15 +457,9 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Runs with a command as an array with a shell and an entrypoint" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_0="echo"
   export BUILDKITE_PLUGIN_DOCKER_COMMAND_1="hello world"
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'
@@ -574,7 +469,7 @@ EOF
   export BUILDKITE_COMMAND=
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint llamas.sh image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint llamas.sh --label com.buildkite.job-id=1-2-3-4 image:tag custom-bash -a -b echo 'hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -582,20 +477,14 @@ EOF
   assert_output --partial "ran command in docker"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_SHELL
-  unset BUILDKITE_COMMAND
 }
 
 @test "Doesn't disclose environment" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_COMMAND='echo hello world'
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export SUPER_SECRET=supersecret
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -603,7 +492,4 @@ EOF
   refute_output --partial "supersecret"
 
   unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_COMMAND
-  unset SUPER_SECRET
-	}
+}


### PR DESCRIPTION
Adds a label to each container that is create with `com.buildkite.job-id=${BUILDKITE_JOB_ID}` so that a `pre-exit` stage can ensure that containers aren't left behind after cancellation. 

Closes #127.