### PR TITLE
Remove debug mode and always print command executed

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,4 +19,4 @@ steps:
     command: "echo hello world"
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        ubuntu: ubuntu:18.04
+        image: ubuntu:18.04

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,10 @@ steps:
     plugins:
       docker-compose#v3.0.2:
         run: tests
+
+  - wait
+  - label: run the plugin
+    command: "echo hello world"
+    plugins:
+      ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
+        ubuntu: ubuntu:18.04

--- a/hooks/command
+++ b/hooks/command
@@ -354,7 +354,8 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
 fi
 
 echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
-echo "$ docker run ${args[*]}" >&2
+echo -ne '\033[90m$\033[0m' >&2
+echo "${args[*]}" >&2
 
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.

--- a/hooks/command
+++ b/hooks/command
@@ -68,13 +68,6 @@ is_macos() {
   [[ "$OSTYPE" =~ ^(darwin) ]]
 }
 
-debug_mode='off'
-if [[ "${BUILDKITE_PLUGIN_DOCKER_DEBUG:-false}" =~ (true|on|1) ]] ; then
-  echo "--- :hammer: Enabling debug mode"
-  # shellcheck disable=SC2034
-  debug_mode='on'
-fi
-
 tty_default='on'
 init_default='on'
 mount_agent_default='on'
@@ -340,12 +333,9 @@ fi
 
 # Assemble the shell and command arguments into the docker arguments
 
-display_command=()
-
 if [[ ${#shell[@]} -gt 0 ]] ; then
   for shell_arg in "${shell[@]}" ; do
     args+=("$shell_arg")
-    display_command+=("$shell_arg")
   done
 fi
 
@@ -354,23 +344,17 @@ if [[ -n "${BUILDKITE_COMMAND}" ]] ; then
     # The windows CMD shell only supports multiple commands with &&.
     windows_multi_command=${BUILDKITE_COMMAND//$'\n'/ && }
     args+=("${windows_multi_command}")
-    display_command+=("'${windows_multi_command}'")
   else
     args+=("${BUILDKITE_COMMAND}")
-    display_command+=("'${BUILDKITE_COMMAND}'")
   fi
 elif [[ ${#command[@]} -gt 0 ]] ; then
   for command_arg in "${command[@]}" ; do
     args+=("$command_arg")
-    display_command+=("${command_arg}")
   done
 fi
 
-echo "--- :docker: Logging \"docker run\" command"
-echo "$ docker run ${args[*]}" >&2
-
 echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
-echo "$ ${display_command[*]}" >&2
+echo "$ docker run ${args[*]}" >&2
 
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.

--- a/hooks/command
+++ b/hooks/command
@@ -354,8 +354,11 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
 fi
 
 echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
-echo -ne '\033[90m$\033[0m' >&2
-echo "${args[*]}" >&2
+echo -ne '\033[90m$\033[0m docker run' >&2
+
+# Print all the arguments, with a space after, properly shell quoted
+printf "%q " "${args[@]}"
+echo
 
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-export DOCKER_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
 
 @test "Run with BUILDKITE_COMMAND" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
@@ -331,28 +331,6 @@ EOF
   unset BUILDKITE_PLUGIN_DOCKER_NETWORK
 }
 
-@test "Runs BUILDKITE_COMMAND with debug mode" {
-  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-  export BUILDKITE_PLUGIN_DOCKER_DEBUG=true
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "Enabling debug mode"
-  assert_output --partial "$ docker run"
-
-  unstub docker
-  unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-  unset BUILDKITE_PLUGIN_DOCKER_DEBUG
-  unset BUILDKITE_COMMAND
-}
-
 @test "Runs BUILDKITE_COMMAND with custom runtime" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
@@ -430,7 +408,7 @@ EOF
 #       (from function `assert_output' in file /usr/local/lib/bats/bats-assert/src/assert.bash, line 231,
 #         in test file tests/command.bats, line 387)
 #         `assert_output --partial "ran command in docker"' failed
-      
+
 #       -- output does not contain substring --
 #       substring : ran command in docker
 #       output    : --- :docker: Running 'echo hello world' in image:tag


### PR DESCRIPTION
This removes the `debug:true` mode in this plugin in favour of always printing the command underneath the command header:

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/15758/58773951-8fac4880-8602-11e9-8add-3ce93db943a6.png">

This uses `printf "%q"` for shell escaping the arguments, so it's copy and paste-able.

Related to https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/117.