### PR TITLE
Add entrypoint disabling tests from #125 (thanks @pecigonzalo)

### DIFF
--- a/tests/command.bats
+++ b/tests/command.bats
@@ -331,44 +331,35 @@ EOF
   unstub docker
 }
 
-# Unfortunately trying to match an empty string argument with bats-mock is impossible:
-#
-#     ✓ Runs BUILDKITE_COMMAND with entrypoint with explicit shell
-#     bats-mock(docker): got docker run -it --rm --init --volume /plugin:/workdir --workdir /workdir --entrypoint  image:tag echo hello world 18/26
-#     bats-mock(docker): match failed at idx 9, expected 'image:tag', got ''''
-#     bats-mock(docker): result 0
-#     ✗ Runs BUILDKITE_COMMAND with null entrypoint
-#       (from function `assert_output' in file /usr/local/lib/bats/bats-assert/src/assert.bash, line 231,
-#         in test file tests/command.bats, line 387)
-#         `assert_output --partial "ran command in docker"' failed
+@test "Runs BUILDKITE_COMMAND with entrypoint disabled by null" {
+  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=''
+  export BUILDKITE_COMMAND="echo hello world"
 
-#       -- output does not contain substring --
-#       substring : ran command in docker
-#       output    : --- :docker: Running 'echo hello world' in image:tag
-#       --
-#
-# So for now, this test is commented out until we find a way to test it.
-#
-# @test "Runs BUILDKITE_COMMAND with null entrypoint" {
-#   export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
-#   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
-#   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=''
-#   export BUILDKITE_COMMAND="echo hello world"
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint '\'\'' image:tag 'echo hello world' : echo ran command in docker"
 
-#   stub docker \
-#     "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint '' image:tag 'echo hello world' : echo ran command in docker"
+  run $PWD/hooks/command
 
-#   run $PWD/hooks/command
+  assert_success
+  assert_output --partial "ran command in docker"
 
-#   assert_success
-#   assert_output --partial "ran command in docker"
+  unstub docker
+}
 
-#   unstub docker
-#   unset BUILDKITE_PLUGIN_DOCKER_IMAGE
-#   unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
-#   unset BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT
-#   unset BUILDKITE_COMMAND
-# }
+@test "Runs BUILDKITE_COMMAND with entrypoint disabled by false" {
+  export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=false
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint '\'\'' image:tag 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
 
 @test "Runs BUILDKITE_COMMAND with shell" {
   export BUILDKITE_PLUGIN_DOCKER_SHELL_0='custom-bash'


### PR DESCRIPTION
This adds the tests for disabling entrypoint with `entrypoint: ''` or `entrypoint: false`. 

