### PR TITLE
Add support for --device flags on docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ You can use the [bk cli](https://github.com/buildkite/cli) to run the test pipel
 docker-compose run --rm tests
 ```
 
+### `devices` (optional, array)
+
+You can give builds limited access to a specific device or devices by passing devices to the docker container, in an array. Items are specific as `SOURCE:TARGET` or just `TARGET`. Each entry corresponds to a Docker CLI `--device` parameter.
+
+Example: `[ "/dev/bus/usb/001/001" ]`
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -135,6 +135,19 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN
   done
 fi
 
+# Ensure devices option is an array
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_DEVICES:-}" ]] ; then
+  echo "🚨 The Docker Plugin’s devices configuration option must be an array."
+  exit 1
+fi
+
+# Parse devices and add them to the docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICES ; then
+  for arg in "${result[@]}" ; do
+    args+=( "--device" "${arg}" )
+  done
+fi
+
 # Ensure sysctl option is an array
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SYSCTLS:-}" ]] ; then
   echo -n "🚨 The Docker Plugin’s sysctl configuration option must be an array."

--- a/plugin.yml
+++ b/plugin.yml
@@ -41,6 +41,8 @@ configuration:
       type: string
     volumes:
       type: array
+    devices:
+      type: array
     tmpfs:
       type: array
     workdir:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -96,6 +96,22 @@ setup() {
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with devices" {
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
+  export BUILDKITE_PLUGIN_DOCKER_DEVICES_0=/dev/bus/usb/001/001
+  export BUILDKITE_COMMAND="echo hello world; pwd"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/app --device /dev/bus/usb/001/001 --workdir /app --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world; pwd' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND with sysctls" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_SYSCTLS_0=net.ipv4.ip_forward=1


### PR DESCRIPTION
This pull requests adds support for `--device` flag for docker run.