### PR TITLE
Remove redundant checks and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ Set namespaced kernel parameters in the container. More information can be found
 
 Example: `--sysctl net.ipv4.ip_forward=1`
 
+### `devices` (optional, array)
+
+You can give builds limited access to a specific device or devices by passing devices to the docker container, in an array. Items are specific as `SOURCE:TARGET` or just `TARGET`. Each entry corresponds to a Docker CLI `--device` parameter.
+
+Example: `[ "/dev/bus/usb/001/001" ]`
+
 ## Developing
 
 You can use the [bk cli](https://github.com/buildkite/cli) to run the test pipeline locally, or just the tests using Docker Compose directly:
@@ -268,12 +274,6 @@ You can use the [bk cli](https://github.com/buildkite/cli) to run the test pipel
 ```bash
 docker-compose run --rm tests
 ```
-
-### `devices` (optional, array)
-
-You can give builds limited access to a specific device or devices by passing devices to the docker container, in an array. Items are specific as `SOURCE:TARGET` or just `TARGET`. Each entry corresponds to a Docker CLI `--device` parameter.
-
-Example: `[ "/dev/bus/usb/001/001" ]`
 
 ## License
 

--- a/hooks/command
+++ b/hooks/command
@@ -100,16 +100,6 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_INIT:-$init_default}" =~ ^(true|on|1)$ ]] ; the
     args+=("--init")
 fi
 
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_MOUNTS:-}" =~ ^(true|false)$ ]] ; then
-  echo "🚨 The Docker Plugin’s mounts configuration option must be an array or a boolean."
-  exit 1
-fi
-
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" && ! "${BUILDKITE_PLUGIN_DOCKER_VOLUMES:-}" =~ ^(true|false)$ ]] ; then
-  echo "🚨 The Docker Plugin’s volumes configuration option must be an array or a boolean."
-  exit 1
-fi
-
 # Parse tmpfs property.
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_TMPFS ; then
   for arg in "${result[@]}" ; do
@@ -135,23 +125,11 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN
   done
 fi
 
-# Ensure devices option is an array
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_DEVICES:-}" ]] ; then
-  echo "🚨 The Docker Plugin’s devices configuration option must be an array."
-  exit 1
-fi
-
 # Parse devices and add them to the docker args
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICES ; then
   for arg in "${result[@]}" ; do
     args+=( "--device" "${arg}" )
   done
-fi
-
-# Ensure sysctl option is an array
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SYSCTLS:-}" ]] ; then
-  echo -n "🚨 The Docker Plugin’s sysctl configuration option must be an array."
-  exit 1
 fi
 
 # Parse sysctl args and add them to docker args
@@ -332,12 +310,6 @@ if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
 fi
 
 command=()
-
-# Show a helpful error message if string version of command is used
-if [[ -n "${BUILDKITE_PLUGIN_DOCKER_COMMAND:-}" ]] ; then
-  echo -n "🚨 The Docker Plugin’s command configuration option must be an array."
-  exit 1
-fi
 
 # Parse plugin command if provided
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_COMMAND ; then

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -442,7 +442,7 @@ EOF
   run $PWD/hooks/command
 
   assert_failure
-  assert_output --partial "command configuration option must be an array"
+  assert_output --partial "🚨 Plugin received a string for BUILDKITE_PLUGIN_DOCKER_COMMAND, expected an array"
 }
 
 @test "Runs with a command as an array" {


### PR DESCRIPTION
This pull request remove redundant checks as `plugin_read_list_into_result` already takes care of that. Also includes a small `README.md` fix.