### PR TITLE
Allow for agent specific vars in volumes and env vars

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -111,6 +111,7 @@ workdir=''
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
   workdir="${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}"
+  workdir=$(eval echo "${workdir}")
 fi
 
 # By default, mount $PWD onto $WORKDIR
@@ -121,7 +122,9 @@ fi
 # Parse volumes (and deprecated mounts) and add them to the docker args
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN_DOCKER_MOUNTS ; then
   for arg in "${result[@]}" ; do
-    args+=( "--volume" "$(expand_relative_volume_path "${arg}")" )
+    expanded_path=$(expand_relative_volume_path "${arg}")
+    actual_expanded_path=$(eval echo "${expanded_path}")
+    args+=( "--volume"  "${actual_expanded_path}")
   done
 fi
 
@@ -141,7 +144,8 @@ fi
 
 # Set workdir if one is provided or if the checkout is mounted
 if [[ -n "${workdir:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]]; then
-  args+=("--workdir" "${workdir}")
+  actual_workdir=$(eval echo ${workdir})
+  args+=("--workdir" "${actual_workdir}")
 fi
 
 # Support docker run --user
@@ -199,7 +203,8 @@ fi
 # Parse extra env vars and add them to the docker args
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_[0-9]+) ]] ; then
-    args+=( "--env" "${!name}" )
+    env_var_val=$(eval echo "${!name}")
+    args+=( "--env" "${env_var_val}" )
   fi
 done < <(env | sort)
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -514,3 +514,33 @@ EOF
 
   unstub docker
 }
+
+@test "Run with dynamic volume mounts" {
+  export BUILDKITE_COMMAND='echo hello world'
+  export BUILDKITE_AGENT_NAME='agent-1'
+  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_0="/path/to/code:/path/to/\$BUILDKITE_AGENT_NAME"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --volume /path/to/code:/path/to/agent-1 --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  unstub docker
+}
+
+@test "Run with dynamic env var values" {
+  export BUILDKITE_COMMAND='echo hello world'
+  export BUILDKITE_AGENT_NAME='agent-1'
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0="MY_VAR=\$BUILDKITE_AGENT_NAME"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env MY_VAR=agent-1 --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  unstub docker
+}


### PR DESCRIPTION
We would like to leverage agent specific metadata described by `BUILDKITE_AGENT_META_DATA_*` in mounting agent specific volumes and passing in agent-specific env var values when spinning up a docker container. 

e.g
```
volumes:
   - "/path/to/$$BUILDKITE_AGENT_NAME:/path/inside/container"
```
The value of `BUILDKITE_AGENT_NAME` doesn't get evaluated by the docker plugin currently at runtime. This change allows us for interpolation of variables in working directory, volumes and env passed to the plugin.

Not a bash expert - so maybe there's a better way to expand/interpolate the param values.