### PR TITLE
Support --userns

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Allows a user to be set, and override the USER entry in the Dockerfile. See http
 
 Example: `root`
 
+### `userns` (optional, string)
+
+Allows to explicitly set the user namespace. This overrides the default docker daemon value. If you use the value `host`, you disable user namespaces for this run. See https://docs.docker.com/engine/security/userns-remap/ for more details.
+
+Example: `mynamespace`
+
 ### `volumes` (optional, array or boolean)
 
 Extra volume mounts to pass to the docker container, in an array. Items are specified as `SOURCE:TARGET`. Each entry corresponds to a Docker CLI `--volume` parameter. Relative local paths are converted to their full-path (e.g `./code:/app`).

--- a/hooks/command
+++ b/hooks/command
@@ -165,6 +165,11 @@ while IFS='=' read -r name _ ; do
   fi
 done < <(env | sort)
 
+# Support docker run --userns
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}" ]]; then
+  args+=("--userns" "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}")
+fi
+
 # Mount ssh-agent socket and known_hosts
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|on|1)$ ]] ; then
   args+=(

--- a/plugin.yml
+++ b/plugin.yml
@@ -39,6 +39,8 @@ configuration:
       type: boolean
     user:
       type: string
+    userns:
+      type: string
     volumes:
       type: array
     devices:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -245,6 +245,21 @@ EOF
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with userns" {
+  export BUILDKITE_PLUGIN_DOCKER_USERNS=foo
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --userns foo --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND with additional groups" {
   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_0=foo
   export BUILDKITE_PLUGIN_DOCKER_ADDITIONAL_GROUPS_1=bar


### PR DESCRIPTION
User namespaces (https://docs.docker.com/engine/security/userns-remap/) are a useful security tool. Sometimes you need fine grain control over them and you want to choose a different one than the default one. This change enables that.