### PR TITLE
Add some better errors when $SSH_AUTH_SOCK is wrong

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -172,6 +172,14 @@ fi
 
 # Mount ssh-agent socket and known_hosts
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|on|1)$ ]] ; then
+  if [[ -z "${SSH_AUTH_SOCK:-}" ]] ; then
+    echo "+++ 🚨 \$SSH_AUTH_SOCK isn't set, has ssh-agent started?"
+    exit 1
+  fi
+  if [[ ! -f "${SSH_AUTH_SOCK}" ]] ; then
+    echo "+++ 🚨 The ssh-agent auth socket at ${SSH_AUTH_SOCK} doesn't exist, has ssh-agent started?"
+    exit 1
+  fi
   args+=(
     "--env" "SSH_AUTH_SOCK=/ssh-agent"
     "--volume" "${SSH_AUTH_SOCK}:/ssh-agent"

--- a/hooks/command
+++ b/hooks/command
@@ -176,8 +176,12 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|o
     echo "+++ 🚨 \$SSH_AUTH_SOCK isn't set, has ssh-agent started?"
     exit 1
   fi
-  if [[ ! -f "${SSH_AUTH_SOCK}" ]] ; then
-    echo "+++ 🚨 The ssh-agent auth socket at ${SSH_AUTH_SOCK} doesn't exist, has ssh-agent started?"
+  if [[ ! -S "${SSH_AUTH_SOCK}" ]] ; then
+    echo "+++ 🚨 There isn't any file at ${SSH_AUTH_SOCK}, has ssh-agent started?"
+    exit 1
+  fi
+  if [[ ! -S "${SSH_AUTH_SOCK}" ]] ; then
+    echo "+++ 🚨 The file at ${SSH_AUTH_SOCK} isn't a socket, has ssh-agent started?"
     exit 1
   fi
   args+=(


### PR DESCRIPTION
Currently we don't provide any helpful errors when users use `mount-ssh-agent` and the `$SSH_AUTH_SOCK` either doesn't exist or points to something that isn't readable.

This adds some better errors. 