### PR TITLE
Set userns=host for the privileged case

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Example: `root`
 
 ### `userns` (optional, string)
 
-Allows to explicitly set the user namespace. This overrides the default docker daemon value. If you use the value `host`, you disable user namespaces for this run. See https://docs.docker.com/engine/security/userns-remap/ for more details.
+Allows to explicitly set the user namespace. This overrides the default docker daemon value. If you use the value `host`, you disable user namespaces for this run. See https://docs.docker.com/engine/security/userns-remap/ for more details. Due to limitations in this feature, a privileged container will override the user specified `userns` value to `host`
 
 Example: `mynamespace`
 

--- a/hooks/command
+++ b/hooks/command
@@ -174,7 +174,14 @@ done < <(env | sort)
 
 # Support docker run --userns
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}" ]]; then
-  args+=("--userns" "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}")
+  # However, if BUILDKITE_PLUGIN_DOCKER_PRIVILEGED is enabled, then userns MUST
+  # be overridden to host per limitations of docker
+  # https://docs.docker.com/engine/security/userns-remap/#user-namespace-known-limitations
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_PRIVILEGED:-false}" =~ ^(true|on|1)$ ]] ; then
+      args+=("--userns" "host")
+  else
+      args+=("--userns" "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}")
+  fi
 fi
 
 # Mount ssh-agent socket and known_hosts


### PR DESCRIPTION
Hello,

Our team noticed a small issue with https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/141 

The original feature request did not handle the `--privileged` use case. With this change, it will now override the user-specific userns value properly.

Feedback appreciated