### PR TITLE
Escape /C to workaround a bug in Git for Windows 2.24.1.2

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -79,7 +79,9 @@ if is_windows ; then
   init_default=''
   mount_agent_default=''
   workdir_default="C:\\workdir"
-  pwd_default="$(cmd.exe /C "echo %CD%")"
+  # escaping /C is a necessary workaround for an issue with Git for Windows 2.24.1.2
+  # https://github.com/git-for-windows/git/issues/2442
+  pwd_default="$(cmd.exe //C "echo %CD%")"
 elif is_macos ; then
   mount_agent_default=''
 fi


### PR DESCRIPTION

This change works with Git for Windows 2.24.1.2 and backwards
compatibility test with 2.22.0 was also successful.

https://github.com/git-for-windows/git/issues/2442
Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>