### PR TITLE
Support buildkite-agent's git-mirrors; mount BUILDKITE_GIT_MIRROR_PATH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -33,7 +33,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -48,7 +48,7 @@ steps:
       - "yarn install"
       - "yarn run test"
     plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -66,7 +66,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -80,7 +80,7 @@ steps:
       - "docker build . -t image:tag"
       - "docker push image:tag"
     plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -93,7 +93,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v3.5.0:
+      - docker#v3.7.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/hooks/command
+++ b/hooks/command
@@ -128,7 +128,8 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN
 fi
 
 # If there's a git mirror, mount it so that git references can be followed.
-if [[ -n "${BUILDKITE_REPO_MIRROR:-}" ]]; then
+# But not if mount-checkout is disabled.
+if [[ -n "${BUILDKITE_REPO_MIRROR:-}" && "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]]; then
   args+=( "--volume" "$BUILDKITE_REPO_MIRROR:$BUILDKITE_REPO_MIRROR:ro" )
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -127,6 +127,11 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_VOLUMES BUILDKITE_PLUGIN
   done
 fi
 
+# If there's a git mirror, mount it so that git references can be followed.
+if [[ -n "${BUILDKITE_REPO_MIRROR:-}" ]]; then
+  args+=( "--volume" "$BUILDKITE_REPO_MIRROR:$BUILDKITE_REPO_MIRROR:ro" )
+fi
+
 # Parse devices and add them to the docker args
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICES ; then
   for arg in "${result[@]}" ; do

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -576,3 +576,39 @@ EOF
 
   unstub docker
 }
+
+@test "Run with BUILDKITE_REPO_MIRROR" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  export BUILDKITE_REPO_MIRROR="/tmp/mirrors/git-github-com-buildkite-agent-abc123"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --volume /tmp/mirrors/git-github-com-buildkite-agent-abc123:/tmp/mirrors/git-github-com-buildkite-agent-abc123:ro --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo hello world"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "hello world"
+
+  unstub docker
+}
+
+@test "Run with BUILDKITE_REPO_MIRROR in addition to other volumes" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  export BUILDKITE_REPO_MIRROR="/tmp/mirrors/git-github-com-buildkite-agent-abc123"
+  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_0="/one:/a"
+  export BUILDKITE_PLUGIN_DOCKER_VOLUMES_1="/two:/b:ro"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --volume /one:/a --volume /two:/b:ro --volume /tmp/mirrors/git-github-com-buildkite-agent-abc123:/tmp/mirrors/git-github-com-buildkite-agent-abc123:ro --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo hello world"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "hello world"
+
+  unstub docker
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -594,6 +594,24 @@ EOF
   unstub docker
 }
 
+@test "Run with BUILDKITE_REPO_MIRROR but mount-checkout=false" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  export BUILDKITE_REPO_MIRROR="/tmp/mirrors/git-github-com-buildkite-agent-abc123"
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT="false"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+
+  stub docker \
+    "run -it --rm --init --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo hello world"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "hello world"
+
+  unstub docker
+}
+
 @test "Run with BUILDKITE_REPO_MIRROR in addition to other volumes" {
   export BUILDKITE_COMMAND="echo hello world"
   export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"


### PR DESCRIPTION
When `BUILDKITE_GIT_MIRROR_PATH` environment is present, that path is automatically mounted to the same location within the container. This makes repos created with `git clone --reference $BUILDKITE_GIT_MIRROR_PATH` accessible within the docker container.

Until https://github.com/buildkite/agent/pull/1311 the agent does not set `BUILDKITE_GIT_MIRROR_PATH`, ~so this pull request is a draft / RFC~.
This functionality will depend on (upcoming) buildkite-agent >= [v3.24.0](https://github.com/buildkite/agent/releases/tag/v3.24.0).

_Same as buildkite-plugins/docker-compose-buildkite-plugin#287 but this one is for docker not docker-compose._
