### PR TITLE
Adds a setting to allow propagating AWS auth tokens (from an assume role plugin) to the container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Whether or not to automatically propagate all pipeline environment variables int
 
 Note that only pipeline variables will automatically be propagated (what you see in the Buildkite UI). Variables set in proceeding hook scripts will not be propagated to the container.
 
+### `propagate-aws-auth-tokens` (optional, boolean)
+
+Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin.
+
+Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`, only if they are set already.
+
 ### `propagate-uid-gid` (optional, boolean)
 
 Whether to match the user ID and group ID for the container user to the user ID and group ID for the host user. It is similar to specifying `user: 1000:1000`, except it avoids hardcoding a particular user/group ID.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ steps:
           propagate-environment: true
 ```
 
+AWS authentication tokens can be automatically propagated to the container, for example from an assume role plugin:
+
+```yml
+steps:
+  - command:
+      - "yarn install"
+      - "yarn run test"
+    env:
+      MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
+    plugins:
+      - docker#v3.7.0:
+          image: "node:7"
+          always-pull: true
+          propagate-aws-auth-tokens: true
+```
+
 You can pass in additional volumes to be mounted. This is useful for running Docker:
 
 ```yml

--- a/hooks/command
+++ b/hooks/command
@@ -267,6 +267,19 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT:-false}" =~ ^(true|on|1)$
   fi
 fi
 
+# Propagate aws auth environment variables into the container e.g. from assume role plugins
+if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on|1)$ ]] ; then
+  if [[ -n "${AWS_ACCESS_KEY_ID:-}" ]] ; then
+      args+=( --env "AWS_ACCESS_KEY_ID" )
+  fi
+  if [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]] ; then
+      args+=( --env "AWS_SECRET_ACCESS_KEY" )
+  fi
+  if [[ -n "${AWS_SESSION_TOKEN:-}" ]] ; then
+      args+=( --env "AWS_SESSION_TOKEN" )
+  fi
+fi
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
   if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \

--- a/plugin.yml
+++ b/plugin.yml
@@ -55,6 +55,8 @@ configuration:
       type: string
     propagate-environment:
       type: boolean
+    propagate-aws-auth-tokens:
+      type: boolean
     propagate-uid-gid:
       type: boolean
     privileged:


### PR DESCRIPTION
This adds a setting `propagate-aws-auth-tokens` which will propagate the following environment variables to the container if they are set:
`AWS_ACCESS_KEY_ID`
`AWS_SECRET_ACCESS_KEY`
`AWS_SESSION_TOKEN`

This allows you to use assume role plugins (which don't expose these via the `BUILDKITE_ENV_FILE` without having to specify `environment` all the time.