### PR TITLE
Add memory control to docker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,27 @@ Set the CPU limit to apply when running the container. More information can be f
 
 Example: `0.5`
 
+### `memory` (optional, string)
+
+Set the memory limit to apply when running the container. More information can 
+be found in https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory.
+
+Example: `2g`
+
+### `memory-swap` (optional, string)
+
+Set the memory swap limit to apply when running the container. More information
+can be found in https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory.
+
+Example: `2g`
+
+### `memory-swappiness` (optional, string)
+
+Set the swappiness level to apply when running the container. More information
+can be found in https://docs.docker.com/config/containers/resource_constraints/#--memory-swappiness-details.
+
+Example: `0`
+
 ## Developing
 
 You can use the [bk cli](https://github.com/buildkite/cli) to run the test pipeline locally, or just the tests using Docker Compose directly:

--- a/hooks/command
+++ b/hooks/command
@@ -328,6 +328,21 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_CPUS:-}" ]]; then
   args+=("--cpus=${BUILDKITE_PLUGIN_DOCKER_CPUS}")
 fi
 
+# Handle memory limit if provided
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY:-}" ]]; then
+  args+=("--memory=${BUILDKITE_PLUGIN_DOCKER_MEMORY}")
+fi
+
+# Handle memory swap limit if provided
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAP:-}" ]]; then
+  args+=("--memory-swap=${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAP}")
+fi
+
+# Handle memory swappiness if provided
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS:-}" ]]; then
+  args+=("--memory-swappiness=${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS}")
+fi
+
 # Handle entrypoint if set (or empty), and default shell to disabled
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT-false}" != "false" ]] ; then
   args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,12 @@ configuration:
       type: string
     ipc:
       type: string
+    memory:
+      type: string
+    memory-swap:
+      type: string
+    memory-swappiness:
+      type: string
     mount-buildkite-agent:
       type: boolean
     mount-ssh-agent:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -670,3 +670,64 @@ EOF
 
   unstub docker
 }
+
+@test "Runs BUILDKITE_COMMAND with memory options" {
+  export BUILDKITE_PLUGIN_DOCKER_MEMORY=2g
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --memory=2g --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with memory-swap options" {
+  export BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAP=2g
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --memory-swap=2g --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with memory-swappiness options" {
+  export BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS=0
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --memory-swappiness=0 --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with implicit no swap" {
+  export BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAP=2g
+  export BUILDKITE_PLUGIN_DOCKER_MEMORY=2g
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --memory=2g --memory-swap=2g --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}


### PR DESCRIPTION
This adds the much-needed memory control to Docker plugin which helps to isolate containers from each-other and the host in case of things like memory leaks.

If there are any additional changes I need to make - just let me know.

We've tested this fork in our production CI setup 👍 