### PR TITLE
Add AWS region with propagate-aws-auth-tokens option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Note that only pipeline variables will automatically be propagated (what you see
 
 Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin.
 
-Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`, only if they are set already.
+Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` and `AWS_DEFAULT_REGION`, only if they are set already.
 
 ### `propagate-uid-gid` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -278,6 +278,12 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   if [[ -n "${AWS_SESSION_TOKEN:-}" ]] ; then
       args+=( --env "AWS_SESSION_TOKEN" )
   fi
+  if [[ -n "${AWS_REGION:-}" ]] ; then
+      args+=( --env "AWS_REGION" )
+  fi
+  if [[ -n "${AWS_DEFAULT_REGION:-}" ]] ; then
+      args+=( --env "AWS_DEFAULT_REGION" )
+  fi
 fi
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -668,9 +668,11 @@ EOF
   export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
   export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   export AWS_SESSION_TOKEN="AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk"
+  export AWS_REGION="ap-southeast-2"
+  export AWS_DEFAULT_REGION="ap-southeast-2"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 


### PR DESCRIPTION
Hi,

I'm getting error about missing region when using propagate-aws-auth-tokens.
This PR is to add the variables when that option is enabled.