### PR TITLE
fix YAML so renovate doesn't complain about invalid configs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,5 @@
       "enabled": false
     }
   },
-  "label": "dependencies"
+  "label": ["dependencies"]
 }


### PR DESCRIPTION
This PR is to address #110 

This should _hopefully_ bring the config in line with the [Renovate docs](https://docs.renovatebot.com/configuration-options/#labels)