### PR TITLE
Changed label to labels in renovate config file as it was not correct

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,5 @@
       "enabled": false
     }
   },
-  "label": ["dependencies"]
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
We added 'label' [here](https://github.com/buildkite-plugins/docker-buildkite-plugin/commit/5ea1c30d3ceaff89fb833311424305039eef16f7) instead of 'labels’. This should fix this issue https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/110