### PR TITLE
Add skip-checkout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,11 @@ Set the size of the `/dev/shm` shared memory filesystem mount inside the docker 
 
 Example: `2gb`
 
-### `skip` (optional, boolean)
+### `skip-checkout` (optional, boolean)
 
 Whether to skip the repository checkout phase.
+
+Default: `false`
 
 ### `storage-opt` (optional, string)
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Set the size of the `/dev/shm` shared memory filesystem mount inside the docker 
 
 Example: `2gb`
 
+### `skip` (optional, boolean)
+
+Whether to skip the repository checkout phase.
+
 ### `storage-opt` (optional, string)
 
 This allows setting the container rootfs size at the creation time. This is only available for the `devicemapper`, `btrfs`, `overlay2`, `windowsfilter` and `zfs` graph drivers. See [docker documentation](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container) for more details.

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ueo pipefail
 
-if [[ ! "${BUILDKITE_PLUGIN_DOCKER_SKIP_CHECKOUT:-off}" =~ ^(true|on|1)$ ]] ; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_SKIP_CHECKOUT:-off}" =~ ^(true|on|1)$ ]] ; then
   echo "~~~ :docker: Skipping checkout"
   export BUILDKITE_REPO=""
 fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ueo pipefail
+
+if [[ ! "${BUILDKITE_PLUGIN_DOCKER_SKIP_CHECKOUT:-off}" =~ ^(true|on|1)$ ]] ; then
+  export BUILDKITE_REPO=""
+fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -2,5 +2,6 @@
 set -ueo pipefail
 
 if [[ ! "${BUILDKITE_PLUGIN_DOCKER_SKIP_CHECKOUT:-off}" =~ ^(true|on|1)$ ]] ; then
+  echo "~~~ :docker: Skipping checkout"
   export BUILDKITE_REPO=""
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -52,7 +52,7 @@ configuration:
     shm-size:
       type: string
     skip-checkout:
-      type: [boolean]
+      type: boolean
     tty:
       type: boolean
     user:

--- a/plugin.yml
+++ b/plugin.yml
@@ -51,6 +51,8 @@ configuration:
       type: [boolean, array]
     shm-size:
       type: string
+    skip-checkout:
+      type: [boolean]
     tty:
       type: boolean
     user:

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+@test "Run without specific options" {
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  refute_line --partial 'Skipping'  # generate no output
+}
+
+
+@test "Run with skip-checkout turned off" {
+  export BUILDKITE_PLUGIN_DOCKER_SKIP_CHECKOUT=false
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  refute_line --partial 'Skipping' # generate no output
+}
+
+
+@test "Run with skip-checkout turned on" {
+  export BUILDKITE_PLUGIN_DOCKER_SKIP_CHECKOUT=true
+
+  run $PWD/hooks/pre-checkout
+  assert_success
+  assert_output --partial 'Skipping' # generate no output
+}

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -26,5 +26,5 @@ load '/usr/local/lib/bats/load.bash'
 
   run $PWD/hooks/pre-checkout
   assert_success
-  assert_output --partial 'Skipping' # generate no output
+  assert_output --partial 'Skipping'
 }


### PR DESCRIPTION
I often meet the case where all the files I need I already contained within the Docker image. In such case, there is no reason to checkout the repository.
The docker-compose plugin already implements this [option](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin#skip-checkout-optional-run-only).
