### PR TITLE
Add options for --cap-add, --cap-drop, and --security-opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,18 @@ Set namespaced kernel parameters in the container. More information can be found
 
 Example: `--sysctl net.ipv4.ip_forward=1`
 
+### `add-caps` (optional, array)
+
+Add Linux capabilities to the container. Each entry corresponds to a Docker CLI `--cap-add` parameter.
+
+### `drop-caps` (optional, array)
+
+Remove Linux capabilities from the container. Each entry corresponds to a Docker CLI `--cap-drop` parameter.
+
+### `security-opts` (optional, array)
+
+Add security options to the container. Each entry corresponds to a Docker CLI `--security-opt` parameter.
+
 ### `devices` (optional, array)
 
 You can give builds limited access to a specific device or devices by passing devices to the docker container, in an array. Items are specific as `SOURCE:TARGET` or just `TARGET`. Each entry corresponds to a Docker CLI `--device` parameter.

--- a/hooks/command
+++ b/hooks/command
@@ -149,6 +149,27 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SYSCTLS ; then
   done
 fi
 
+# Parse cap-add args and add them to docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_ADD_CAPS ; then
+  for arg in "${result[@]}"; do
+    args+=("--cap-add" "$arg")
+  done
+fi
+
+# Parse cap-drop args and add them to docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DROP_CAPS ; then
+  for arg in "${result[@]}"; do
+    args+=("--cap-drop" "$arg")
+  done
+fi
+
+# Parse security-opts args and add them to docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SECURITY_OPTS ; then
+  for arg in "${result[@]}"; do
+    args+=("--security-opt" "$arg")
+  done
+fi
+
 # Set workdir if one is provided or if the checkout is mounted
 if [[ -n "${workdir:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]]; then
   args+=("--workdir" "${workdir}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -81,6 +81,12 @@ configuration:
       type: array
     storage-opt:
       type: string
+    add-caps:
+      type: array
+    drop-caps:
+      type: array
+    security-opts:
+      type: array
   required:
     - image
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -808,3 +808,37 @@ EOF
 
   unstub docker
 }
+
+
+@test "Runs BUILDKITE_COMMAND with one added capability" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_ADD_CAPS_0='cap-0'
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --cap-add cap-0 --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+
+@test "Runs BUILDKITE_COMMAND with multiple added capabilities" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_ADD_CAPS_0='cap-0'
+  export BUILDKITE_PLUGIN_DOCKER_ADD_CAPS_1='cap-1'
+  export BUILDKITE_PLUGIN_DOCKER_ADD_CAPS_2='cap-2'
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --cap-add cap-0 --cap-add cap-1 --cap-add cap-2 --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -875,3 +875,37 @@ EOF
 
   unstub docker
 }
+
+
+@test "Runs BUILDKITE_COMMAND with one security opt" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_SECURITY_OPTS_0='sec-0=1'
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --security-opt 'sec-0=1' --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+
+@test "Runs BUILDKITE_COMMAND with multiple security opts" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_SECURITY_OPTS_0='sec-0=1'
+  export BUILDKITE_PLUGIN_DOCKER_SECURITY_OPTS_1='sec-1:0'
+  export BUILDKITE_PLUGIN_DOCKER_SECURITY_OPTS_2='sec-2=1:0'
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --security-opt 'sec-0=1' --security-opt 'sec-1:0' --security-opt 'sec-2=1:0'  --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -842,3 +842,36 @@ EOF
 
   unstub docker
 }
+
+@test "Runs BUILDKITE_COMMAND with one dropped capability" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_DROP_CAPS_0='cap-0'
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --cap-drop cap-0 --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+
+@test "Runs BUILDKITE_COMMAND with multiple dropped capabilities" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_DROP_CAPS_0='cap-0'
+  export BUILDKITE_PLUGIN_DOCKER_DROP_CAPS_1='cap-1'
+  export BUILDKITE_PLUGIN_DOCKER_DROP_CAPS_2='cap-2'
+
+  stub docker \
+    "run -it --rm --init --volume $PWD:/workdir --cap-drop cap-0 --cap-drop cap-1 --cap-drop cap-2 --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}


### PR DESCRIPTION
This is the exact same thing as #171 but added missing tests (which could not be done as the original fork no longer exists). I was able, though, to keep the original commit intact to respect to the original author.