### PR TITLE
Fix plugins (and `--entrypoint` behaviour)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -33,7 +33,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -50,7 +50,7 @@ steps:
       - "yarn install"
       - "yarn run test"
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -86,7 +86,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -100,7 +100,7 @@ steps:
       - "docker build . -t image:tag"
       - "docker push image:tag"
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -113,7 +113,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v3.13.0:
+      - docker#v4.0.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Enables debug mode, which outputs the full Docker commands that will be run on t
 
 Default: `false`
 
-### `entrypoint` (optional, string or boolean)
+### `entrypoint` (optional, string)
 
-Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details. Set it to `""` (empty string) to disable the default entrypoint for the image (you may also need to use this plugin's `command` option instead of the top-level `command` option - see [Issue 138](https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/138) for more information).
+Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details. Set it to `""` (empty string) to disable the default entrypoint for the image, but note that you may need to use this plugin's `command` option instead of the top-level `command` option or set a `shell` instead (depending on the command you want/need to run - see [Issue 138](https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/138) for more information).
 
 Example: `/my/custom/entrypoint.sh`, `""`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v3.0.0
     volumes:
       - ".:/plugin:ro"

--- a/hooks/command
+++ b/hooks/command
@@ -388,8 +388,8 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS:-}" ]]; then
 fi
 
 # Handle entrypoint if set (or empty), and default shell to disabled
-if [[ "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT-false}" != "false" ]] ; then
-  args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT:-}")
+if [[ -v BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT ]] ; then
+  args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT}")
   shell_disabled=1
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,7 +18,7 @@ configuration:
     debug:
       type: boolean
     entrypoint:
-      type: [string, boolean]
+      type: string
     environment:
       type: array
     image:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -484,7 +484,7 @@ EOF
   unstub docker
 }
 
-@test "Runs BUILDKITE_COMMAND with entrypoint disabled by null" {
+@test "Runs BUILDKITE_COMMAND with entrypoint disabled by empty string" {
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=''
   export BUILDKITE_COMMAND="echo hello world"
 
@@ -499,12 +499,12 @@ EOF
   unstub docker
 }
 
-@test "Runs BUILDKITE_COMMAND with entrypoint disabled by false" {
+@test "Runs BUILDKITE_COMMAND with entrypoint set as false" {
   export BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT=false
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint $'''' --label com.buildkite.job-id=1-2-3-4 image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint false --label com.buildkite.job-id=1-2-3-4 image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -489,7 +489,7 @@ EOF
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint '\'\'' image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint $'''' --label com.buildkite.job-id=1-2-3-4 image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 
@@ -504,7 +504,7 @@ EOF
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint '\'\'' image:tag 'echo hello world' : echo ran command in docker"
+    "run -it --rm --init --volume $PWD:/workdir --workdir /workdir --entrypoint $'''' --label com.buildkite.job-id=1-2-3-4 image:tag 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 


### PR DESCRIPTION
This fixes the 2 tests that started failing since the release of the latest plugin tester.

That uncovered a bug in the tests themselves of the `--entrypoint` option which is what actually caused #138. The easiest solution to which was to just remove the alternative of the plugin option to be a boolean. It needs to be a string that will be used as-is and updated the documentation accordingly.

Due to the complex interaction between entrypoint, shell and command as defined in this plugin, the docker container and the pipeline that actually used the plugin I left the reference to the issue in the documentation.