### PR TITLE
Change `mount-buildkite-agent` default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -33,7 +33,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -50,7 +50,7 @@ steps:
       - "yarn install"
       - "yarn run test"
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -86,7 +86,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -100,7 +100,7 @@ steps:
       - "docker build . -t image:tag"
       - "docker push image:tag"
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -113,7 +113,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v4.0.0:
+      - docker#v4.1.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Default: `true`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container.
 
-Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X or Widnows agent binary in a container running linux). If enabled in Windows agents your pipeline, step or agent **must have the `BUILDKITE_AGENT_BINARY_PATH` environment variable defined** with the executable to mount in the (Windows) agent.
+Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X or Windows agent binary in a container running linux). If enabled in Windows agents your pipeline, step or agent **must have the `BUILDKITE_AGENT_BINARY_PATH` environment variable defined** with the executable to mount in the (Windows) agent.
 
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Default: `true`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container.
 
-Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X agent binary in a container running linux).
+Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X or Widnows agent binary in a container running linux). If enabled in Windows agents your pipeline, step or agent **must have the `BUILDKITE_AGENT_BINARY_PATH` environment variable defined** with the executable to mount in the (Windows) agent.
 
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -33,7 +33,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -50,7 +50,7 @@ steps:
       - "yarn install"
       - "yarn run test"
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -86,7 +86,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -100,7 +100,7 @@ steps:
       - "docker build . -t image:tag"
       - "docker push image:tag"
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -113,7 +113,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v4.1.0:
+      - docker#v5.0.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ Default: `true`
 
 ### `mount-buildkite-agent` (optional, boolean)
 
-Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Set to `false` if you want to disable, or if you already have your own binary in the image.
+Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container.
+
+Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X agent binary in a container running linux).
 
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ Default: `true`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container. Set to `false` if you want to disable, or if you already have your own binary in the image.
 
-Default: `true` for Linux, and `false` for macOS and Windows.
+Default: `false`
+
+**Important:** enabling this option will share `BUILDKITE_AGENT_TOKEN` environment variable (and others) with the container
 
 ### `mount-ssh-agent` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -69,7 +69,7 @@ is_macos() {
 tty_default='on'
 interactive_default='on'
 init_default='on'
-mount_agent_default='on'
+mount_agent_default='off'
 mount_ssh_agent=''
 pwd_default="$PWD"
 workdir_default="/workdir"
@@ -78,13 +78,10 @@ workdir_default="/workdir"
 if is_windows ; then
   tty_default=''
   init_default=''
-  mount_agent_default=''
   workdir_default="C:\\workdir"
   # escaping /C is a necessary workaround for an issue with Git for Windows 2.24.1.2
   # https://github.com/git-for-windows/git/issues/2442
   pwd_default="$(cmd.exe //C "echo %CD%")"
-elif is_macos ; then
-  mount_agent_default=''
 fi
 
 args=()

--- a/hooks/command
+++ b/hooks/command
@@ -73,6 +73,7 @@ mount_agent_default='off'
 mount_ssh_agent=''
 pwd_default="$PWD"
 workdir_default="/workdir"
+agent_mount_folder="/usr/bin/buildkite-agent"
 
 # Set operating system specific defaults
 if is_windows ; then
@@ -82,7 +83,11 @@ if is_windows ; then
   # escaping /C is a necessary workaround for an issue with Git for Windows 2.24.1.2
   # https://github.com/git-for-windows/git/issues/2442
   pwd_default="$(cmd.exe //C "echo %CD%")"
+
+  # single quotes are important to avoid double-escaping the already escaped backslash
+  agent_mount_folder='C:\\buildkite-agent'
 fi
+
 
 args=()
 
@@ -240,7 +245,10 @@ fi
 # Handle the mount-buildkite-agent option
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-$mount_agent_default}" =~ ^(true|on|1)$ ]] ; then
   if [[ -z "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
-    if ! command -v buildkite-agent >/dev/null 2>&1 ; then
+    if is_windows; then
+      echo -n "+++ 🚨 You must specify the variable BUILDKITE_AGENT_BINARY_PATH to mount the agent in Windows"
+      exit 1
+    elif ! command -v buildkite-agent >/dev/null 2>&1 ; then
       echo -n "+++ 🚨 Failed to find buildkite-agent in PATH to mount into container, "
       echo "you can disable this behaviour with 'mount-buildkite-agent:false'"
     else
@@ -255,7 +263,7 @@ if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
     "--env" "BUILDKITE_JOB_ID"
     "--env" "BUILDKITE_BUILD_ID"
     "--env" "BUILDKITE_AGENT_ACCESS_TOKEN"
-    "--volume" "$BUILDKITE_AGENT_BINARY_PATH:/usr/bin/buildkite-agent"
+    "--volume" "$BUILDKITE_AGENT_BINARY_PATH:${agent_mount_folder}"
   )
 fi
 


### PR DESCRIPTION
This changes the default for the option and adds a warning in the readme associated to the option.

**Important**: this means that this should be a major release as it changes default behaviour

Closes #149
Closes #157 
Closes #154 