### PR TITLE
Testing of exit code propagation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,3 +20,10 @@ steps:
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         image: ubuntu:20.04
+  - label: ensure exit codes are propagated
+    command: "exit 3"
+    plugins:
+      ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
+        image: ubuntu:20.04
+    soft_fail:
+      - exit_status: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester:v3.0.0
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - ".:/plugin:ro"

--- a/hooks/command
+++ b/hooks/command
@@ -477,6 +477,16 @@ echo -ne '\033[90m$\033[0m docker run ' >&2
 printf "%q " "${args[@]}"
 echo
 
+# Disable -e outside of the subshell; since the subshell returning a failure
+# would exit the parent shell (here) early.
+set +e
+
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.
 ( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && docker run "${args[@]}" )
+
+exit_code=$?
+
+set -e
+
+exit $exit_code  # propagate exit code

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -964,3 +964,46 @@ EOF
 
   unstub docker
 }
+
+@test "Run with BUILDKITE_COMMAND that exits with a failure" {
+  export BUILDKITE_COMMAND='pwd'
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : exit 1"
+
+  run $PWD/hooks/command
+
+  assert_failure
+  assert_output --partial "Running command in"
+
+  unstub docker
+}
+
+@test "Run with BUILDKITE_COMMAND propagates exit codes" {
+  export BUILDKITE_COMMAND='pwd'
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : exit 2"
+
+  run $PWD/hooks/command
+
+  assert_failure 2
+  assert_output --partial "Running command in"
+
+  unstub docker
+}
+
+
+@test "Run with BUILDKITE_COMMAND propagates subshell exit codes" {
+  export BUILDKITE_COMMAND='pwd'
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : sh -c 'exit 2'"
+
+  run $PWD/hooks/command
+
+  assert_failure 2
+  assert_output --partial "Running command in"
+
+  unstub docker
+}


### PR DESCRIPTION
Adds unit tests to the plugin to review exit code propagation and adds a step to the pipeline to ensure that is the case.

If successful this should close #191 