### PR TITLE
Add ulimits support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -33,7 +33,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -50,7 +50,7 @@ steps:
       - "yarn install"
       - "yarn run test"
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -86,7 +86,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -100,7 +100,7 @@ steps:
       - "docker build . -t image:tag"
       - "docker push image:tag"
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -113,7 +113,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v5.1.0:
+      - docker#v5.2.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ Remove Linux capabilities from the container. Each entry corresponds to a Docker
 
 Add security options to the container. Each entry corresponds to a Docker CLI `--security-opt` parameter.
 
+### `ulimits` (optional, array)
+
+Add ulimit options to the container. Each entry corresponds to a Docker CLI `--ulimit` parameter.
+
 ### `devices` (optional, array)
 
 You can give builds limited access to a specific device or devices by passing devices to the docker container, in an array. Items are specific as `SOURCE:TARGET` or just `TARGET`. Each entry corresponds to a Docker CLI `--device` parameter.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -33,7 +33,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -50,7 +50,7 @@ steps:
       - "yarn install"
       - "yarn run test"
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -86,7 +86,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -100,7 +100,7 @@ steps:
       - "docker build . -t image:tag"
       - "docker push image:tag"
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -113,7 +113,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v5.0.0:
+      - docker#v5.1.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/hooks/command
+++ b/hooks/command
@@ -183,6 +183,13 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SECURITY_OPTS ; then
   done
 fi
 
+# Parse ulimits args and add them to docker args
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_ULIMITS ; then
+  for arg in "${result[@]}"; do
+    args+=("--ulimit" "$arg")
+  done
+fi
+
 # Set workdir if one is provided or if the checkout is mounted
 if [[ -n "${workdir:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]]; then
   args+=("--workdir" "${workdir}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -93,6 +93,8 @@ configuration:
       type: array
     security-opts:
       type: array
+    ulimits:
+      type: array
   required:
     - image
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1012,6 +1012,38 @@ EOF
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with one ulimit" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_ULIMITS_0='nofile=1024'
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --ulimit 'nofile=1024' --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+
+@test "Runs BUILDKITE_COMMAND with multiple ulimits" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_ULIMITS_0='nofile=1024'
+  export BUILDKITE_PLUGIN_DOCKER_ULIMITS_1='nproc=2048'
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --ulimit 'nofile=1024' --ulimit 'nproc=2048' --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND without interactive option" {
   export BUILDKITE_PLUGIN_DOCKER_INTERACTIVE=0
   export BUILDKITE_COMMAND="echo hello world"


### PR DESCRIPTION
Adds support for `docker run --ulimit` (https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit) under the `ulimits:` plugin option.

Tested with a local pipeline:
<img width="1099" alt="Screen Shot 2022-09-27 at 3 41 06 PM" src="https://user-images.githubusercontent.com/3876970/192620397-c3de54c5-9f71-402c-a1f4-0fe3dcee0266.png">
<img width="1099" alt="Screen Shot 2022-09-27 at 3 41 52 PM" src="https://user-images.githubusercontent.com/3876970/192620538-4b7b0fc7-0195-476d-a6f7-33a0659b88b9.png">

`ulimit -a` output:
<img width="444" alt="Screen Shot 2022-09-27 at 3 21 20 PM" src="https://user-images.githubusercontent.com/3876970/192620434-50eb1b23-5577-42d5-9bfa-b0ad555730f6.png">
