### PR TITLE
Pass ECS env vars when using propagate-aws-auth-tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ steps:
           propagate-environment: true
 ```
 
-AWS authentication tokens can be automatically propagated to the container, for example from an assume role plugin:
+AWS authentication tokens can be automatically propagated to the container, for example from an assume role plugin or ECS IAM role:
 
 ```yml
 steps:
@@ -191,9 +191,9 @@ Note that only pipeline variables will automatically be propagated (what you see
 
 ### `propagate-aws-auth-tokens` (optional, boolean)
 
-Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin.
+Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin or you want to pass the role of an agent running in ECS to the docker container.
 
-Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` and `AWS_DEFAULT_REGION`, only if they are set already.
+Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, only if they are set already.
 
 ### `propagate-uid-gid` (optional, boolean)
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Note that only pipeline variables will automatically be propagated (what you see
 
 Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin or you want to pass the role of an agent running in ECS to the docker container.
 
-Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, only if they are set already.
+Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and `AWS_CONTAINER_AUTHORIZATION_TOKEN`, only if they are set already.
 
 ### `propagate-uid-gid` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -330,6 +330,9 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   if [[ -n "${AWS_DEFAULT_REGION:-}" ]] ; then
       args+=( --env "AWS_DEFAULT_REGION" )
   fi
+  if [[ -n "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}" ]] ; then
+      args+=( --env "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" )
+  fi
 fi
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then

--- a/hooks/command
+++ b/hooks/command
@@ -330,8 +330,16 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   if [[ -n "${AWS_DEFAULT_REGION:-}" ]] ; then
       args+=( --env "AWS_DEFAULT_REGION" )
   fi
+  # Pass ECS variables when the agent is running in ECS
+  # https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+  if [[ -n "${AWS_CONTAINER_CREDENTIALS_FULL_URI:-}" ]] ; then
+      args+=( --env "AWS_CONTAINER_CREDENTIALS_FULL_URI" )
+  fi
   if [[ -n "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}" ]] ; then
       args+=( --env "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" )
+  fi
+  if [[ -n "${AWS_CONTAINER_AUTHORIZATION_TOKEN:-}" ]] ; then
+      args+=( --env "AWS_CONTAINER_AUTHORIZATION_TOKEN" )
   fi
 fi
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -822,10 +822,12 @@ EOF
   export AWS_SESSION_TOKEN="AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk"
   export AWS_REGION="ap-southeast-2"
   export AWS_DEFAULT_REGION="ap-southeast-2"
+  export AWS_CONTAINER_CREDENTIALS_FULL_URI="http://localhost:8080/get-credentials"
   export AWS_CONTAINER_CREDENTIALS_RELATIVE_URI="/get-credentials?a=1"
+  export AWS_CONTAINER_AUTHORIZATION_TOKEN="Basic abcd"
 
   stub docker \
-    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_FULL_URI --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --env AWS_CONTAINER_AUTHORIZATION_TOKEN --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -822,9 +822,10 @@ EOF
   export AWS_SESSION_TOKEN="AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk"
   export AWS_REGION="ap-southeast-2"
   export AWS_DEFAULT_REGION="ap-southeast-2"
+  export AWS_CONTAINER_CREDENTIALS_RELATIVE_URI="/get-credentials?a=1"
 
   stub docker \
-    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run $PWD/hooks/command
 


### PR DESCRIPTION
When the agent is running in ECS, credentials are obtained by the various AWS SDKs by contacting `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. This PR passes this env var from the agent to the docker container if it's defined.

Update: Also passes `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN`