### PR TITLE
Xmas 2022 updates

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,11 +19,11 @@ steps:
     command: "echo hello world"
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        image: ubuntu:20.04
+        image: ubuntu:22.04
   - label: ensure exit codes are propagated
     command: "exit 3"
     plugins:
       ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        image: ubuntu:20.04
+        image: ubuntu:22.04
     soft_fail:
       - exit_status: 3

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
 
   - label: ":docker: :hammer:"
     plugins:
-      docker-compose#v4.5.0:
+      docker-compose#v4.9.0:
         run: tests
 
   - wait

--- a/hooks/command
+++ b/hooks/command
@@ -65,10 +65,12 @@ expand_relative_volume_path() {
   fi
 }
 
+# shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
 is_windows() {
   [[ "$OSTYPE" =~ ^(win|msys|cygwin) ]]
 }
 
+# shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
 is_macos() {
   [[ "$OSTYPE" =~ ^(darwin) ]]
 }
@@ -355,7 +357,7 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \
        docker pull "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" ; then
     echo "!!! :docker: Pull failed."
-    exit $retry_exit_status
+    exit "$retry_exit_status"
   fi
 fi
 


### PR DESCRIPTION
- Updates to `hooks/command` for shellcheck
    -  `shellcheck disable=SC2317` for false positives.
        To fix shellcheck prompt: `SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).`
       According to [shellcheck wiki](https://www.shellcheck.net/wiki/SC2317):
        >ShellCheck may incorrectly believe that code is unreachable if it's invoked by variable name or in a trap.
    - Added double quotes around `$retry_exit_status` exit code.
      To fix shellcheck prompt: `SC2086 (info): Double quote to prevent globbing and word splitting.`
- Updated docker-compose plugin usage from v4.5.0 to v4.9.0
- Updated Ubuntu 20.04 LTS to Ubuntu 22.04 LTS