### PR TITLE
Plugin tester update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester:v3.0.1
+    image: buildkite/plugin-tester:v4.0.0
     volumes:
       - ".:/plugin:ro"

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -7,7 +7,7 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD"/hooks/pre-checkout
 
   assert_success
-  refute_line --partial 'Skipping'  # generate no output
+  refute_output  # generate no output
 }
 
 
@@ -17,7 +17,7 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD"/hooks/pre-checkout
 
   assert_success
-  refute_line --partial 'Skipping' # generate no output
+  refute_output  # generate no output
 }
 
 

--- a/tests/windows.bats
+++ b/tests/windows.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+setup() {
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_JOB_ID="1-2-3-4"
+  export BUILDKITE_PLUGIN_DOCKER_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_COMMAND="pwd"
+  export OSTYPE="win" # important to define these test as windows
+}
+
+@test "Run with BUILDKITE_COMMAND" {
+  export BUILDKITE_COMMAND='command1 "a string"'
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+
+  stub cmd.exe \
+    "//C $'echo %CD%' : echo WIN_PATH"
+
+  stub docker \
+    "run -i --rm --volume \* --workdir \* --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume \* --label com.buildkite.job-id=1-2-3-4 image:tag CMD.EXE /c 'command1 \"a string\"' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unstub cmd.exe
+}


### PR DESCRIPTION
Updates plugin tester to latest version. For which I had to correct 2 tests.

Taking advantage of the new version, I also added one test for Windows (that could not be tested due to a [bug in the bats-mock library](https://github.com/buildkite-plugins/bats-mock/issues/9))