### PR TITLE
`known_hosts` path customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ Default: `false`
 
 **Important:** enabling this option will share `BUILDKITE_AGENT_TOKEN` environment variable (and others) with the container
 
-### `mount-ssh-agent` (optional, boolean)
+### `mount-ssh-agent` (optional, boolean or string)
 
-Whether to automatically mount the ssh-agent socket from the host agent machine into the container (at `/ssh-agent`and `/root/.ssh/known_hosts` respectively), allowing git operations to work correctly.
+Whether to mount the ssh-agent socket (at `/ssh-agent`) from the host agent machine into the container or not. Instead of just `true` or `false`, you can specify absolute path in the container for the home directory of the user used to run on which the agent's `.ssh/known_hosts` will be mounted (by default, `/root`).
 
 Default: `false`
 

--- a/hooks/command
+++ b/hooks/command
@@ -79,7 +79,6 @@ tty_default='on'
 interactive_default='on'
 init_default='on'
 mount_agent_default='off'
-mount_ssh_agent=''
 pwd_default="$PWD"
 workdir_default="/workdir"
 agent_mount_folder="/usr/bin/buildkite-agent"
@@ -238,7 +237,7 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}" ]]; then
 fi
 
 # Mount ssh-agent socket and known_hosts
-if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|on|1)$ ]] ; then
+if [[ ! "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-false}" = 'false' ]] ; then
   if [[ -z "${SSH_AUTH_SOCK:-}" ]] ; then
     echo "+++ 🚨 \$SSH_AUTH_SOCK isn't set, has ssh-agent started?"
     exit 1
@@ -251,10 +250,17 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|o
     echo "+++ 🚨 The file at ${SSH_AUTH_SOCK} isn't a socket, has ssh-agent started?"
     exit 1
   fi
+
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-''}" =~ ^(true|on|1)$ ]]; then
+    MOUNT_PATH=/root
+  else
+    MOUNT_PATH="${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT}"
+  fi
+
   args+=(
     "--env" "SSH_AUTH_SOCK=/ssh-agent"
     "--volume" "${SSH_AUTH_SOCK}:/ssh-agent"
-    "--volume" "${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts"
+    "--volume" "${HOME}/.ssh/known_hosts:${MOUNT_PATH}/.ssh/known_hosts"
   )
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -243,11 +243,7 @@ if [[ ! "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-false}" = 'false' ]] ; then
     exit 1
   fi
   if [[ ! -S "${SSH_AUTH_SOCK}" ]] ; then
-    echo "+++ 🚨 There isn't any file at ${SSH_AUTH_SOCK}, has ssh-agent started?"
-    exit 1
-  fi
-  if [[ ! -S "${SSH_AUTH_SOCK}" ]] ; then
-    echo "+++ 🚨 The file at ${SSH_AUTH_SOCK} isn't a socket, has ssh-agent started?"
+    echo "+++ 🚨 There file at ${SSH_AUTH_SOCK} does not exist or is not a socket, has ssh-agent started?"
     exit 1
   fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -247,10 +247,10 @@ if [[ ! "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-false}" = 'false' ]] ; then
     exit 1
   fi
 
-  if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT:-''}" =~ ^(true|on|1)$ ]]; then
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-''}" =~ ^(true|on|1)$ ]]; then
     MOUNT_PATH=/root
   else
-    MOUNT_PATH="${BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT}"
+    MOUNT_PATH="${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT}"
   fi
 
   args+=(

--- a/plugin.yml
+++ b/plugin.yml
@@ -38,7 +38,7 @@ configuration:
     mount-buildkite-agent:
       type: boolean
     mount-ssh-agent:
-      type: boolean
+      type: [ boolean, string ]
     mount-checkout:
       type: boolean
     network:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1167,3 +1167,37 @@ EOF
 
   unstub docker
 }
+
+@test "Use ssh agent (true)" {
+  skip 'Can not create a socket for testing :('
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT=true
+  export SSH_AUTH_SOCK="/tmp/sock" 
+  touch /tmp/sock # does not work as the hook checks that this is a socket
+
+  stub docker \
+    "run -t -i --rm --init --volume \* --workdir \* --env SSH_AUTH_SOCK=/ssh-agent --volume /tmp/sock:/ssh-agent --volume /root/.ssh/known_hosts:/root/.ssh/known_hosts --label \* image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Use ssh agent (with path)" {
+  skip 'Can not create a socket for testing :('
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT=/test/path
+  export SSH_AUTH_SOCK="/tmp/sock" 
+  touch /tmp/sock # does not work as the hook checks that this is a socket
+
+  stub docker \
+    "run -t -i --rm --init --volume \* --workdir \* --env SSH_AUTH_SOCK=/ssh-agent --volume /tmp/sock:/ssh-agent --volume /root/.ssh/known_hosts:/test/path/.ssh/known_hosts --label \* image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}


### PR DESCRIPTION
Changes the way `mount-ssh-agent` works so that you can customize where the known_hosts file is mounted

Closes #232 