### PR TITLE
`env-propagation-list`: programmatically propagate envvars to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,17 @@ Example: `[ "BUILDKITE_MESSAGE", "MY_SECRET_KEY", "MY_SPECIAL_BUT_PUBLIC_VALUE=k
 
 An array of additional files to pass into to the docker container as environment variables. Each entry corresponds to a Docker CLI `--env-file` parameter.
 
+### `env-propagation-list` (optional, string)
+
+If you set this to `VALUE`, and `VALUE` is an environment variable containing a space-separated list of environment variables such as `A B C D`, then A, B, C, and D will all be propagated to the container. This is helpful when you've set up an `environment` hook to export secrets as environment variables, and you'd also like to programmatically ensure that secrets get propagated to containers, instead of listing them all out.
+
 ### `propagate-environment` (optional, boolean)
 
-Whether or not to automatically propagate all pipeline environment variables into the docker container. Avoiding the need to be specified with `environment`.
+Whether or not to automatically propagate all* pipeline environment variables into the docker container. Avoiding the need to be specified with `environment`.
 
 Note that only pipeline variables will automatically be propagated (what you see in the Buildkite UI). Variables set in proceeding hook scripts will not be propagated to the container.
+
+\* Caveat: only environment variables listed in $BUILDKITE_ENV_FILE will be propagated. This does not include e.g. variables that you exported in an `environment` hook. If you wish for those to be propagated, try `env-propagation-list`.
 
 ### `propagate-aws-auth-tokens` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -310,6 +310,17 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_ENV_FILE; then
   done
 fi
 
+# If requested, propagate a set of env vars as listed in a given env var to the
+# container.
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_ENV_PROPAGATION_LIST:-}" ]]; then
+  if [[ -z "${!BUILDKITE_PLUGIN_DOCKER_ENV_PROPAGATION_LIST:-}" ]]; then
+    echo -n "env-propagation-list desired, but ${BUILDKITE_PLUGIN_DOCKER_ENV_PROPAGATION_LIST} is not defined!"
+    exit 1
+  fi
+  for var in ${!BUILDKITE_PLUGIN_DOCKER_ENV_PROPAGATION_LIST}; do
+    args+=("--env" "$var")
+  done
+fi
 
 # Propagate all environment variables into the container if requested
 if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT:-false}" =~ ^(true|on|1)$ ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,8 @@ configuration:
       type: array
     env-file:
       type: array
+    env-propagation-list:
+      type: string
     image:
       type: string
     ipc:


### PR DESCRIPTION
Hi! Like many others, https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/184 , I tried setting env vars in a hook, then was surprised when `propagate-environment` didn't propagate them to the container.

Here is my proposal for how to fix this. Instead of changing the behavior of `propagate-environment`, add a new option `env-propagation-list`, which:
> If you set this to `VALUE`, and `VALUE` is an environment variable containing a space-separated list of environment variables such as `A B C D`, then A, B, C, and D will all be propagated to the container. This is helpful when you've set up an `environment` hook to export secrets as environment variables, and you'd also like to programmatically ensure that secrets get propagated to containers, instead of listing them all out.

Here's how to use it: in your `environment` hook, where you would normally be generating bash statements like:
```
export SECRET_1="one"
export SECRET_2="two"
```
You can instead do:
```
export SECRET_1="one"
export PROPAGATE_LIST="SECRET_1 ${PROPAGATE_LIST:-}"
export SECRET_2="two"
export PROPAGATE_LIST="SECRET_2 ${PROPAGATE_LIST:-}"
```
Then, when you invoke this plugin, give it `propagate-list: 'PROPAGATE_LIST'`, and those vars you set will end up in the container, too.