### PR TITLE
add `arbitrary-flags`, which runs a given arbitrary script in order to generate more flags to `docker run`

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -529,6 +529,14 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
+# Support running an arbitrary shell script to generate a list of additional
+# options to pass to docker.
+arbitrary_script="${BUILDKITE_PLUGIN_DOCKER_ARBITRARY_FLAGS:-}"
+arbitrary_args=""
+if [[ -n "$arbitrary_script" ]] ; then
+  arbitrary_args=$(bash -c "$arbitrary_script")
+fi
+
 echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
 echo -ne '\033[90m$\033[0m docker run ' >&2
 
@@ -542,7 +550,7 @@ set +e
 
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.
-( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && docker run "${args[@]}" )
+( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && docker run $arbitrary_args "${args[@]}" )
 
 exit_code=$?
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -97,6 +97,8 @@ configuration:
       type: array
     ulimits:
       type: array
+    arbitrary_flags:
+      type: string
   required:
     - image
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1227,3 +1227,18 @@ EOF
 
   unstub docker
 }
+
+@test "Runs BUILDKITE_COMMAND with a set of arbitrary flags" {
+  export BUILDKITE_PLUGIN_DOCKER_ARBITRARY_FLAGS="echo --test1=1 --test2=2"
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run --test1=1 --test2=2 -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}


### PR DESCRIPTION
For my workload, I happen to need to run docker like `docker run --group-add=$(getent group docker | cut -d: -f3)`. I cannot do exactly that with this plugin currently, and have to resort to `docker run --group-add=997` which feels bad because the number is pretty inscrutible, also it's fragile.

So I'm opening this PR to start a discussion of how we can allow arbitrary flags generated at runtime. What do you think about this or something like this, allowing the user to define at runtime what args `docker run` is going to get?