### PR TITLE
Bash <4.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "golang:1.11"
 ```
 
@@ -23,7 +23,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -35,7 +35,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -50,7 +50,7 @@ Note: If you are utilizing Buildkite's [Elastic CI Stack S3 Secrets plugin](http
 steps:
   - command: "yarn install; yarn run test"
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "node:7"
           always-pull: true
           environment:
@@ -68,7 +68,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -82,7 +82,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -94,7 +94,7 @@ You can pass in additional volumes to be mounted. This is useful for running Doc
 steps:
   - command: "docker build . -t image:tag; docker push image:tag"
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -107,7 +107,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v5.4.0:
+      - docker#v5.5.1:
           image: "node:7"
           always-pull: true
           mount-checkout: false

--- a/hooks/command
+++ b/hooks/command
@@ -451,7 +451,7 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS:-}" ]]; then
 fi
 
 # Handle entrypoint if set, and default shell to disabled
-if [[ ! -z ${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT+x} ]]; then
+if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT+x} ]]; then
   args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT}")
   shell_disabled=1
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -450,8 +450,8 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS:-}" ]]; then
   args+=("--memory-swappiness=${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS}")
 fi
 
-# Handle entrypoint if set (or empty), and default shell to disabled
-if [[ -v BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT ]] ; then
+# Handle entrypoint if set, and default shell to disabled
+if [[ ! -z ${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT+x} ]]; then
   args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT}")
   shell_disabled=1
 fi


### PR DESCRIPTION
Old bash versions do not have the `-v` test to check for variables being set.

Replaced it with a more universal construct that achieves the same objective.