### PR TITLE
Support for --platform arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ Join the container to the docker network specified. The network will be created 
 
 Example: `test-network`
 
+### `platform` (optional, string)
+
+Platform defines the target platform containers for this service will run on, using the os[/arch[/variant]] syntax. The values of os, arch, and variant MUST conform to the convention used by the OCI Image Spec.
+
+Example: `linux/arm64`
+
 ### `pid` (optional, string)
 
 PID namespace provides separation of processes. The PID Namespace removes the view of the system processes, and allows process ids to be reused including pid 1. See https://docs.docker.com/engine/reference/run/#pid-settings---pid for more details. By default, all containers have the PID namespace enabled.

--- a/hooks/command
+++ b/hooks/command
@@ -386,6 +386,11 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}" ]] ; then
   args+=("--network" "${BUILDKITE_PLUGIN_DOCKER_NETWORK:-}")
 fi
 
+# Support docker run --platform
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_PLATFORM:-}" ]] ; then
+  args+=("--platform" "${BUILDKITE_PLUGIN_DOCKER_PLATFORM:-}")
+fi
+
 # Support docker run --pid
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_PID:-}" ]] ; then
   args+=("--pid" "${BUILDKITE_PLUGIN_DOCKER_PID:-}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -73,6 +73,8 @@ configuration:
       type: array
     workdir:
       type: string
+    platform:
+      type: string
     propagate-environment:
       type: boolean
     propagate-aws-auth-tokens:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -713,9 +713,6 @@ EOF
   export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/${DOCKER_ARCH}
   export BUILDKITE_COMMAND="echo hello world"
 
-  # peaking in on docker to see
-  echo $(docker --version)
-
   stub docker \
     "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --platform linux/${DOCKER_ARCH} --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -380,22 +380,6 @@ setup() {
   unstub docker
 }
 
-@test "Runs BUILDKITE_COMMAND with platform" {
-  export BK_ARCH=$(arch | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
-  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/${BK_ARCH}
-  export BUILDKITE_COMMAND="echo hello world"
-
-  stub docker \
-    "run -t -i --rm --platform linux/${BK_ARCH} --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
-
-  run "$PWD"/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in docker"
-
-  unstub docker
-}
-
 @test "Runs BUILDKITE_COMMAND with pid namespace" {
   export BUILDKITE_PLUGIN_DOCKER_PID=host
   export BUILDKITE_COMMAND="echo hello world"
@@ -715,6 +699,25 @@ EOF
 
   stub docker \
     "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --add-host buildkite.fake:127.0.0.1 --add-host www.buildkite.local:0.0.0.0 --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with platform" {
+  export DOCKER_ARCH=$(arch | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
+  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/${DOCKER_ARCH}
+  export BUILDKITE_COMMAND="echo hello world"
+
+  # peaking in on docker to see
+  echo $(docker --version)
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --platform linux/${DOCKER_ARCH} --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run "$PWD"/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -709,12 +709,11 @@ EOF
 }
 
 @test "Runs BUILDKITE_COMMAND with platform" {
-  export DOCKER_ARCH=$(arch | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
-  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/${DOCKER_ARCH}
+  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/amd64
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --platform linux/${DOCKER_ARCH} --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --platform linux/amd64 --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run "$PWD"/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -380,6 +380,21 @@ setup() {
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with platform" {
+  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/$(arch)
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -t -i --rm --platform linux/$(arch) --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND with pid namespace" {
   export BUILDKITE_PLUGIN_DOCKER_PID=host
   export BUILDKITE_COMMAND="echo hello world"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -381,11 +381,12 @@ setup() {
 }
 
 @test "Runs BUILDKITE_COMMAND with platform" {
-  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/$(arch)
+  export BK_ARCH=$(arch | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
+  export BUILDKITE_PLUGIN_DOCKER_PLATFORM=linux/${BK_ARCH}
   export BUILDKITE_COMMAND="echo hello world"
 
   stub docker \
-    "run -t -i --rm --platform linux/$(arch) --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -t -i --rm --platform linux/${BK_ARCH} --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run "$PWD"/hooks/command
 


### PR DESCRIPTION
use case: i want to run a cluster of mostly linux/amd64, but i need to test on arm too.  rolling up an agent just for that is more work than just running on an arm capable container. 