### PR TITLE
Allow expanding environment variables in image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Example: `node:7`
 
 ### Optional
 
+### `expand-image-vars` (optional, boolean, unsafe)
+
+When set to true, it will activate interpolation of variables in the elements of the `image` configuration variable. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed as the image name.
+
+Environment variable interporation rules apply here. `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
+
+:warning: **Important:** this is considered an unsafe option as the most compatible way to achieve this is to run the strings through `eval` which could lead to arbitrary code execution or information leaking if you don't have complete control of the pipeline
+
 ### `add-host` (optional, array)
 
 Additional lines can be added to `/etc/hosts` in the container, in an array of mappings. See https://docs.docker.com/engine/reference/run/#managing-etchosts for more details.

--- a/README.md
+++ b/README.md
@@ -129,14 +129,6 @@ Example: `node:7`
 
 ### Optional
 
-### `expand-image-vars` (optional, boolean, unsafe)
-
-When set to true, it will activate interpolation of variables in the elements of the `image` configuration variable. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed as the image name.
-
-Environment variable interporation rules apply here. `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
-
-:warning: **Important:** this is considered an unsafe option as the most compatible way to achieve this is to run the strings through `eval` which could lead to arbitrary code execution or information leaking if you don't have complete control of the pipeline
-
 ### `add-host` (optional, array)
 
 Additional lines can be added to `/etc/hosts` in the container, in an array of mappings. See https://docs.docker.com/engine/reference/run/#managing-etchosts for more details.
@@ -188,6 +180,14 @@ An array of additional files to pass into to the docker container as environment
 ### `env-propagation-list` (optional, string)
 
 If you set this to `VALUE`, and `VALUE` is an environment variable containing a space-separated list of environment variables such as `A B C D`, then A, B, C, and D will all be propagated to the container. This is helpful when you've set up an `environment` hook to export secrets as environment variables, and you'd also like to programmatically ensure that secrets get propagated to containers, instead of listing them all out.
+
+### `expand-image-vars` (optional, boolean, unsafe)
+
+When set to true, it will activate interpolation of variables in the elements of the `image` configuration variable. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed as the image name.
+
+Environment variable interporation rules apply here. `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
+
+:warning: **Important:** this is considered an unsafe option as the most compatible way to achieve this is to run the strings through `eval` which could lead to arbitrary code execution or information leaking if you don't have complete control of the pipeline
 
 ### `propagate-environment` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -365,10 +365,16 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   fi
 fi
 
+if [[ "${BUILDKITE_PLUGIN_DOCKER_EXPAND_IMAGE_VARS:-false}" =~ ^(true|on|1)$ ]] ; then
+  image=$(eval echo "${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
+else
+  image="${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+fi
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
-  echo "--- :docker: Pulling ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+  echo "--- :docker: Pulling ${image}"
   if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \
-       docker pull "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" ; then
+       docker pull "${image}" ; then
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi
@@ -487,7 +493,7 @@ fi
 args+=("--label" "com.buildkite.job-id=${BUILDKITE_JOB_ID}")
 
 # Add the image in before the shell and command
-args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
+args+=("${image}")
 
 # Set a default shell if one is needed
 if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
@@ -534,7 +540,7 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+echo "--- :docker: Running command in ${image}"
 echo -ne '\033[90m$\033[0m docker run ' >&2
 
 # Print all the arguments, with a space after, properly shell quoted

--- a/plugin.yml
+++ b/plugin.yml
@@ -27,6 +27,8 @@ configuration:
       type: string
     image:
       type: string
+    expand-image-vars:
+      type: boolean
     ipc:
       type: string
     leave-container:

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,10 +25,10 @@ configuration:
       type: array
     env-propagation-list:
       type: string
-    image:
-      type: string
     expand-image-vars:
       type: boolean
+    image:
+      type: string
     ipc:
       type: string
     leave-container:


### PR DESCRIPTION
Add a new configuration option, `expand-image-vars`, that, when set to true, `eval`s the image name to expand environment variables.

In particular, my main use case is that we have agents running in multiple AWS regions, and we configure ECR replication such that all our images should always be available on the same region that the agents are running. In this setup, it is desired to specify an image URI from the same region as the agent is running at. However, this is currently not possible to achieve without knowing, beforehand, the region where the agent that will pick up the job is running, as the region needs to be explicitly encoded in the image URI.

This PR makes it possible to do that by allowing the image name to contain environment variables, and hence allows it to reference `AWS_DEFAULT_REGION`.