### PR TITLE
feat: Add AWS Web Idenity compability to PROPAGATE_AWS_AUTH_TOKENS

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Note that only pipeline variables will automatically be propagated (what you see
 
 Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin or you want to pass the role of an agent running in ECS or EKS to the docker container.
 
-Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_STS_REGIONAL_ENDPOINTS`, `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and `AWS_CONTAINER_AUTHORIZATION_TOKEN`, only if they are set already.
+Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_STS_REGIONAL_ENDPOINTS`, `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and `AWS_CONTAINER_AUTHORIZATION_TOKEN`, only if they are set already.
 
 When the `AWS_WEB_IDENTITY_TOKEN_FILE` is specified, it will also mount it automatically for you and make it usable within the container.
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,11 @@ Note that only pipeline variables will automatically be propagated (what you see
 
 ### `propagate-aws-auth-tokens` (optional, boolean)
 
-Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin or you want to pass the role of an agent running in ECS to the docker container.
+Whether or not to automatically propagate aws authentication environment variables into the docker container. Avoiding the need to be specified with `environment`. This is useful for example if you are using an assume role plugin or you want to pass the role of an agent running in ECS or EKS to the docker container.
 
-Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and `AWS_CONTAINER_AUTHORIZATION_TOKEN`, only if they are set already.
+Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_STS_REGIONAL_ENDPOINTS`, `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and `AWS_CONTAINER_AUTHORIZATION_TOKEN`, only if they are set already.
+
+When the `AWS_WEB_IDENTITY_TOKEN_FILE` is specified, it will also mount it automatically for you and make it usable within the container.
 
 ### `propagate-uid-gid` (optional, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -352,6 +352,9 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   if [[ -n "${AWS_DEFAULT_REGION:-}" ]] ; then
       args+=( --env "AWS_DEFAULT_REGION" )
   fi
+  if [[ -n "${AWS_STS_REGIONAL_ENDPOINTS:-}" ]] ; then
+      args+=( --env "AWS_STS_REGIONAL_ENDPOINTS" )
+  fi
   # Pass ECS variables when the agent is running in ECS
   # https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
   if [[ -n "${AWS_CONTAINER_CREDENTIALS_FULL_URI:-}" ]] ; then
@@ -362,6 +365,13 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   fi
   if [[ -n "${AWS_CONTAINER_AUTHORIZATION_TOKEN:-}" ]] ; then
       args+=( --env "AWS_CONTAINER_AUTHORIZATION_TOKEN" )
+  fi
+  # Pass EKS variables when the agent is running in EKS
+  # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html
+  if [[ -n "${AWS_WEB_IDENTITY_TOKEN_FILE:-}" ]] ; then
+      args+=( --env "AWS_WEB_IDENTITY_TOKEN_FILE" )
+      # Add the token file as a volume
+      args+=( --volume "${AWS_WEB_IDENTITY_TOKEN_FILE}:${AWS_WEB_IDENTITY_TOKEN_FILE}" )
   fi
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -352,6 +352,9 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   if [[ -n "${AWS_DEFAULT_REGION:-}" ]] ; then
       args+=( --env "AWS_DEFAULT_REGION" )
   fi
+  if [[ -n "${AWS_ROLE_ARN:-}" ]] ; then
+      args+=( --env "AWS_ROLE_ARN" )
+  fi
   if [[ -n "${AWS_STS_REGIONAL_ENDPOINTS:-}" ]] ; then
       args+=( --env "AWS_STS_REGIONAL_ENDPOINTS" )
   fi

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -866,6 +866,7 @@ EOF
   export AWS_SESSION_TOKEN="AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk"
   export AWS_REGION="ap-southeast-2"
   export AWS_DEFAULT_REGION="ap-southeast-2"
+  export AWS_ROLE_ARN="arn:aws:iam::0000000000:role/example-role"
   export AWS_CONTAINER_CREDENTIALS_FULL_URI="http://localhost:8080/get-credentials"
   export AWS_CONTAINER_CREDENTIALS_RELATIVE_URI="/get-credentials?a=1"
   export AWS_CONTAINER_AUTHORIZATION_TOKEN="Basic abcd"
@@ -873,7 +874,7 @@ EOF
   export AWS_WEB_IDENITY_TOKEN_FILE="/tmp/fake-token"
 
   stub docker \
-    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_FULL_URI --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --env AWS_CONTAINER_AUTHORIZATION_TOKEN --env AWS_STS_REGIONAL_ENDPOINTS --env AWS_WEB_IDENITY_TOKEN_FILE --volume "/tmp/fake-token:/tmp/fake-token" --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_FULL_URI --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --env AWS_CONTAINER_AUTHORIZATION_TOKEN --env AWS_STS_REGIONAL_ENDPOINTS --env AWS_WEB_IDENITY_TOKEN_FILE --env AWS_ROLE_ARN --volume "/tmp/fake-token:/tmp/fake-token" --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run "$PWD"/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -869,9 +869,11 @@ EOF
   export AWS_CONTAINER_CREDENTIALS_FULL_URI="http://localhost:8080/get-credentials"
   export AWS_CONTAINER_CREDENTIALS_RELATIVE_URI="/get-credentials?a=1"
   export AWS_CONTAINER_AUTHORIZATION_TOKEN="Basic abcd"
+  export AWS_STS_REGIONAL_ENDPOINTS="true"
+  export AWS_WEB_IDENITY_TOKEN_FILE="/tmp/fake-token"
 
   stub docker \
-    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_FULL_URI --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --env AWS_CONTAINER_AUTHORIZATION_TOKEN --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN --env AWS_REGION --env AWS_DEFAULT_REGION --env AWS_CONTAINER_CREDENTIALS_FULL_URI --env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI --env AWS_CONTAINER_AUTHORIZATION_TOKEN --env AWS_STS_REGIONAL_ENDPOINTS --env AWS_WEB_IDENITY_TOKEN_FILE --volume "/tmp/fake-token:/tmp/fake-token" --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
 
   run "$PWD"/hooks/command
 


### PR DESCRIPTION
This adds compatibilty with AWS authentication using delegated authentication using web identity token files (useful with AWS EKS for example). It adds an environment variable and a volume if the AWS_WEB_IDENTITY_TOKEN_FILE is present to be able to use them from the specified container.

In addition, we have added the AWS_STS_REGION_ENDPOINTS variable compatibility which allows you AWS IAM calls to be directed towards the region you are in instead of redirecting automatically to us-east-1 by default.

If you need more explanation or have concerns with the code, I'll be happy to address and/or correct them if needed :)