### PR TITLE
Add Docker labels to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ Specify the IPC mode to use. See the [docker run options documentation](https://
 
 Example: `host`
 
+### `run-labels` (optional, boolean)
+
+If set to true, adds useful Docker labels to the container. See [Container Labels](#container-labels) for more info.
+
+The default is `true`.
+
 ### `shell` (optional, array or boolean)
 
 Set the shell to use for the command. Set it to `false` to pass the command directly to the `docker run` command. The default is `["/bin/sh", "-e", "-c"]` unless you have provided an `entrypoint` or `command`.
@@ -425,6 +431,26 @@ Set the swappiness level to apply when running the container. More information
 can be found in https://docs.docker.com/config/containers/resource_constraints/#--memory-swappiness-details.
 
 Example: `0`
+
+## Container Labels
+
+When running a command, the plugin will automatically add the following Docker labels to the container:
+- `com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}`
+- `com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}`
+- `com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}`
+- `com.buildkite.job_id=${BUILDKITE_JOB_ID}`
+- `com.buildkite.job_label=${BUILDKITE_LABEL}`
+- `com.buildkite.step_key=${BUILDKITE_STEP_KEY}`
+- `com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}`
+- `com.buildkite.agent_id=${BUILDKITE_AGENT_ID}`
+
+These labels can make it easier to query containers on hosts using `docker ps` for example:
+
+```bash
+docker ps --filter "label=com.buildkite.job_label=Run tests"
+```
+
+This behaviour can be disabled with the `run-labels: false` option.
 
 ## Developing
 

--- a/hooks/command
+++ b/hooks/command
@@ -503,7 +503,21 @@ elif plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_SHELL ; then
 fi
 
 # Add the job id as meta-data for reference in pre-exit
-args+=("--label" "com.buildkite.job-id=${BUILDKITE_JOB_ID}")
+args+=("--label" "com.buildkite.job-id=${BUILDKITE_JOB_ID}")  # Keep the kebab-case one for backwards compat
+
+# Add useful labels to run container
+if [[ "${BUILDKITE_PLUGIN_DOCKER_RUN_LABELS:-true}" =~ ^(true|on|1)$ ]] ; then
+  args+=(
+    "--label" "com.buildkite.pipeline_name=${BUILDKITE_PIPELINE_NAME}"
+    "--label" "com.buildkite.pipeline_slug=${BUILDKITE_PIPELINE_SLUG}"
+    "--label" "com.buildkite.build_number=${BUILDKITE_BUILD_NUMBER}"
+    "--label" "com.buildkite.job_id=${BUILDKITE_JOB_ID}"
+    "--label" "com.buildkite.job_label=${BUILDKITE_LABEL}"
+    "--label" "com.buildkite.step_key=${BUILDKITE_STEP_KEY}"
+    "--label" "com.buildkite.agent_name=${BUILDKITE_AGENT_NAME}"
+    "--label" "com.buildkite.agent_id=${BUILDKITE_AGENT_ID}"
+  )
+fi
 
 # Add the image in before the shell and command
 args+=("${image}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -53,6 +53,8 @@ configuration:
       type: string
     runtime:
       type: string
+    run-labels:
+      type: boolean
     shell:
       type: [boolean, array]
     shm-size:

--- a/tests/windows.bats
+++ b/tests/windows.bats
@@ -9,6 +9,7 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"
   export OSTYPE="win" # important to define these test as windows
+  export BUILDKITE_PLUGIN_DOCKER_RUN_LABELS="false"
 }
 
 @test "Run with BUILDKITE_COMMAND" {


### PR DESCRIPTION
Same changes as https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/376. This is useful to us since we can map labels to Datadog tags and track metrics and usage from the containers spawned by the agent using this plugin.

Based on the discussion in https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/376#issuecomment-1449177002, I've made the option default to `true`, since it's unlikely to break anything, but we still want to give the option to turn it off.

Tested on our infra:
![image](https://github.com/buildkite-plugins/docker-buildkite-plugin/assets/3876970/f69948b0-de91-4aca-b241-6e4a21630251)
