### PR TITLE
Allow setting and expanding . for the workdir

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -61,6 +61,7 @@ workdir=''
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
   workdir="${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}"
+  workdir=$(expand_relative_path "${workdir}")
 fi
 
 # By default, mount $PWD onto $WORKDIR

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -47,6 +47,19 @@ function plugin_read_list_into_result() {
   [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
+# docker doesn't do local path expansion, so we add very simple support for .
+function expand_relative_path() {
+  local path=$1
+
+  if [[ $path =~ ^\.: ]] ; then
+    printf "%s" "${PWD}${path#.}"
+  elif [[ $path =~ ^\.(/|\\) ]] ; then
+    printf "%s" "${PWD}/${path#.}"
+  else
+    echo "$path"
+  fi
+}
+
 # docker's -v arguments don't do local path expansion, so we add very simple support for .
 function expand_relative_volume_path() {
   local path
@@ -57,13 +70,7 @@ function expand_relative_volume_path() {
     path="$1"
   fi
 
-  if [[ $path =~ ^\.: ]] ; then
-    printf "%s" "${PWD}${path#.}"
-  elif [[ $path =~ ^\.(/|\\) ]] ; then
-    printf "%s" "${PWD}/${path#.}"
-  else
-    echo "$path"
-  fi
+  expand_relative_path "$path"
 }
 
 # shellcheck disable=SC2317  # Don't warn about unreachable commands in this function


### PR DESCRIPTION
This will make it easier to use docker-in-docker type builds that need to mount workdir relative files/directories in the child docker run.