### PR TITLE
improve handling of SIGTERM grace period

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -50,7 +50,11 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_INIT:-$init_default}" =~ ^(true|on|1)$ ]] ; the
     args+=("--init")
 fi
 
-args+=("--stop-timeout" "${BUILDKITE_CANCEL_GRACE_PERIOD:-10}")
+# Explicitly set --stop-timout to match BUILDKITE_CANCEL_GRACE_PERIOD, unless
+# BUILDKITE_CANCEL_GRACE_PERIOD is 10, which is the default for both
+if [ "${BUILDKITE_CANCEL_GRACE_PERIOD:-10}" != "10" ] ; then
+    args+=("--stop-timeout" "${BUILDKITE_CANCEL_GRACE_PERIOD:-10}")
+fi
 
 # Parse tmpfs property.
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_TMPFS ; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -50,6 +50,8 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_INIT:-$init_default}" =~ ^(true|on|1)$ ]] ; the
     args+=("--init")
 fi
 
+args+=("--stop-timeout" "${BUILDKITE_CANCEL_GRACE_PERIOD:-10}")
+
 # Parse tmpfs property.
 if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_TMPFS ; then
   for arg in "${result[@]}" ; do
@@ -511,9 +513,14 @@ echo
 # would exit the parent shell (here) early.
 set +e
 
+# Prevent SIGTERM from killing this script. SIGTERM will still be passed to the Docker container, which can exit
+# gracefully (or, if necessary, non-gracefully per the `--stop-timeout` flag passed above).
+trap '' SIGTERM
+
 # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
 # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.
-( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && docker run "${args[@]}" )
+# `trap` is used in this subshell for the same reason it is used above.
+( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && trap '' SIGTERM && docker run "${args[@]}" )
 
 exit_code=$?
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1274,6 +1274,23 @@ EOF
   unstub docker
 }
 
+@test "Runs with BUILDKITE_COMMAND with non-default grace period" {
+  export BUILDKITE_COMMAND='command1 "a string"'
+  export BUILDKITE_AGENT_BINARY_PATH="/buildkite-agent"
+  export BUILDKITE_CANCEL_GRACE_PERIOD="40"
+  unset BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT
+
+  stub docker \
+    "run -t -i --rm --init --stop-timeout 40 --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume /buildkite-agent:/usr/bin/buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'command1 \"a string\"' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Use ssh agent (true)" {
   skip 'Can not create a socket for testing :('
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT=true


### PR DESCRIPTION
This PR makes this plugin behave more similarly to non-Docker jobs with regards to cancellation and timing out.

Consider the following scenario: You have a job which can timeout (or be cancelled by the user), but you want to shutdown gracefully, and conditionally mark the job as passed, if the key parts of the job succeeded before the cancellation.

A typical example would be a benchmark job. When the timeout is hit, it is possible that enough iterations of the benchmark have already run to give a pass.

<img width="728" alt="image" src="https://github.com/buildkite-plugins/docker-buildkite-plugin/assets/9353807/ecd1b70b-27d1-4691-883f-f230f2245559">

When creating a normal (non-Docker) Buildkite job, this is easy. In your test process you add a signal handler for SIGTERM (which is what Buildkite sends on timeout or user cancellation) which conditionally returns exit code 0 (instead of the typical 143). If 0 is returned, Buildkite interprets that as a pass and marks the job with a green tick.

Unfortunately, this doesn't currently work with the Docker plugin. So I've made the following changes:

1. I've added some `trap` calls to the script to ensure that `SIGTERM` only affects the Docker container, not the wrapper bash script. Without this, `SIGTERM` was causing the bash script to terminate and return 143, which meant the exit code from the Docker container was being ignored. Now, if the process inside the Docker container chooses to intercept the `SIGTERM` and e.g. return 0, then the exit code is propagated all the way up to Buildkite UI (which displays a green tick if the exit code is 0).
2. `BUILDKITE_CANCEL_GRACE_PERIOD` is now passed to the Docker container: When a user presses cancel (or a job hits its timeout), Buildkite sends `SIGTERM` to the job. The process is given this grace period to gracefully terminate, before Buildkite resorts to sending a `SIGKILL`. Docker itself has a similar flag option `--stop-timeout`, which was previously defaulting to 10 seconds. So, with that Docker default taking effect, increasing `BUILDKITE_CANCEL_GRACE_PERIOD` had no effect.