### PR TITLE
SUP-1767 Update readme on mount-checkout behavior with git mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Specify a file to load a docker image from. If omitted no load will be done.
 
 Whether to automatically mount the current working directory which contains your checked out codebase. Mounts onto `/workdir`, unless `workdir` is set, in which case that will be used.
 
-If there's a git mirror path and `mount-checkout` is enabled, the (mirror path)[https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REPO_MIRROR] is mounted into the docker container as an added volume. 
+If there's a git mirror path and `mount-checkout` is enabled, the (mirror path)[https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REPO_MIRROR] is mounted into the docker container as an added volume. Otherwise, the git mirror path will have to be explicitly added as an extra volume to mount into the container. 
 
 Default: `true`
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Specify a file to load a docker image from. If omitted no load will be done.
 
 Whether to automatically mount the current working directory which contains your checked out codebase. Mounts onto `/workdir`, unless `workdir` is set, in which case that will be used.
 
+If there's a git mirror path and `mount-checkout` is enabled, the (mirror path)[https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REPO_MIRROR] is mounted into the docker container as an added volume. 
+
 Default: `true`
 
 ### `mount-buildkite-agent` (optional, boolean)


### PR DESCRIPTION
A customer encountered bad object references errors when running `git fetch` using the docker plugin. After checking the issue, the user had `mount-checkout:false`. This means the git mirror path is not mounted into the docker container as opposed to the plugin's default behaviour. 

This PR adds a short description of the plugin's default behaviour of git mirrors paths in the readme.

 