### PR TITLE
Fix test for tester v4.1.1

### DIFF
--- a/tests/command.bats
+++ b/tests/command.bats
@@ -102,7 +102,7 @@ setup() {
   export BUILDKITE_COMMAND="pwd"
 
   stub docker \
-    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN '--volume' '/tmp/bin/buildkite-agent:/usr/bin/buildkite-agent' --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume \* --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker with buildkite agent mounted at \${17}"
 
   # only for the command to exist
   stub buildkite-agent \
@@ -113,6 +113,7 @@ setup() {
   assert_success
   refute_output --partial "🚨 Failed to find buildkite-agent"
   assert_output --partial "ran command in docker"
+  assert_output --partial "/bin/buildkite-agent:/usr/bin/buildkite-agent"  # check agent is mounted
 
   unstub docker
   unstub buildkite-agent || true


### PR DESCRIPTION
In the new update of the tester, the path of stubs can change from test to test (which is a good thing), but there was one test that assumed it was the regular temporary folder so that started failing (see #266).

This change fixes that by accepting any string in that position for the stub,. using it as part of the stub's output and then running an `assert-output` to make sure that the string contains relative paths to the buildkite agent as expected :)