### PR TITLE
feat: add GCP workload identity federation compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ Will propagate `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
 
 When the `AWS_WEB_IDENTITY_TOKEN_FILE` is specified, it will also mount it automatically for you and make it usable within the container.
 
+### `propagate-gcp-auth-tokens` (optional, boolean)
+
+Whether or not to automatically propagate gcp auth credentials into the docker container. Avoiding the need to be specified with `environment`. This is useful if you are using a workload identity federation to impersonate a service account and you want to pass it to the docker container. This is compatible with the `gcp-workload-identity-federation` plugin.
+
+Will propagate `GOOGLE_APPLICATION_CREDENTIALS`, `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` and `BUILDKITE_OIDC_TMPDIR` and also mount the dir specified by `BUILDKITE_OIDC_TMPDIR` into the container.
+
 ### `propagate-uid-gid` (optional, boolean)
 
 Whether to match the user ID and group ID for the container user to the user ID and group ID for the host user. It is similar to specifying `user: 1000:1000`, except it avoids hardcoding a particular user/group ID.

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -316,6 +316,22 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   fi
 fi
 
+# Propagate gcp auth environment variables into the container e.g. from workload identity federation plugins
+if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_GCP_AUTH_TOKENS:-false}" =~ ^(true|on|1)$ ]] ; then
+  if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] ; then
+      args+=( --env "GOOGLE_APPLICATION_CREDENTIALS" )
+  fi
+  if [[ -n "${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE:-}" ]] ; then
+      args+=( --env "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE" )
+  fi
+  if [[ -n "${BUILDKITE_OIDC_TMPDIR:-}" ]] ; then
+      args+=( --env "BUILDKITE_OIDC_TMPDIR" )
+      # Add the OIDC temp dir as a volume
+      args+=( --volume "${BUILDKITE_OIDC_TMPDIR}:${BUILDKITE_OIDC_TMPDIR}" )
+  fi
+
+fi
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_EXPAND_IMAGE_VARS:-false}" =~ ^(true|on|1)$ ]] ; then
   image=$(eval echo "${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
 else

--- a/plugin.yml
+++ b/plugin.yml
@@ -93,6 +93,8 @@ configuration:
       type: boolean
     propagate-aws-auth-tokens:
       type: boolean
+    propagate-gcp-auth-tokens:
+      type: boolean
     propagate-uid-gid:
       type: boolean
     privileged:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -968,6 +968,25 @@ EOF
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with propagate gcp auth tokens" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_PLUGIN_DOCKER_PROPAGATE_GCP_AUTH_TOKENS=true
+
+  export BUILDKITE_OIDC_TMPDIR="/tmp/.tmp.Xdasd23"
+  export GOOGLE_APPLICATION_CREDENTIALS="${BUILDKITE_OIDC_TMPDIR}/credentials.json"
+  export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env GOOGLE_APPLICATION_CREDENTIALS --env CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE --env BUILDKITE_OIDC_TMPDIR --volume \"/tmp/.tmp.Xdasd23:/tmp/.tmp.Xdasd23\" --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND with memory options" {
   export BUILDKITE_PLUGIN_DOCKER_MEMORY=2g
   export BUILDKITE_COMMAND="echo hello world"


### PR DESCRIPTION
We run our workloads in Google Cloud and thus need to identify with a workload identity provider. I noticed for the AWS counterpart there is special support with `propagate-aws-auth-tokens`.

This adds support for the `gcp-workload-identity-federation` plugin and works similar to the AWS token support.
It will expose the env vars set by `gcp-workload-identity-federation` and mount the OIDC temp dir created by the plugin.

I wonder if in the future these can be more abstracted to avoid adding a setting for each cloud provider.