### PR TITLE
Job api mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Set to `true` if you want to enable and are sure that the binary running in the 
 
 Default: `false`
 
-**Important:** enabling this option will share `BUILDKITE_AGENT_TOKEN` environment variable (and others) with the container
+**Important:** enabling this option will share the `BUILDKITE_AGENT_TOKEN` and `BUILDKITE_AGENT_JOB_API_TOKEN` environment variables (and other related ones) with the container if present.
 
 ### `mount-ssh-agent` (optional, boolean or string)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -223,6 +223,14 @@ if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
   )
 fi
 
+if [[ -n "${BUILDKITE_AGENT_JOB_API_SOCKET:-}" ]] ; then
+  args+=(
+    "--env" "BUILDKITE_AGENT_JOB_API_SOCKET"
+    "--env" "BUILDKITE_AGENT_JOB_API_TOKEN"
+    "--volume" "$BUILDKITE_AGENT_JOB_API_SOCKET:$BUILDKITE_AGENT_JOB_API_SOCKET"
+  )
+fi
+
 # Parse extra env vars and add them to the docker args
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_[0-9]+) ]] ; then


### PR DESCRIPTION
Automates Job API variable and socket mounting when sharing the buildkite agent executable as well.

Closes #271 