### PR TITLE
Workdir interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Example: `[ "/var/run/docker.sock:/var/run/docker.sock" ]`
 
 ### `expand-volume-vars` (optional, boolean, run only, unsafe)
 
-When set to true, it will activate interpolation of variables in the elements of the `volumes` configuration array. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed to the `-v` option.
+When set to true, it will activate interpolation of variables in the elements of the `volumes` configuration array as well as `workdir`. When turned off (the default), attempting to use variables will fail as the literal `$VARIABLE_NAME` string will be passed to the `-v` option.
 
 Environment variable interporation rules apply here. `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -66,7 +66,7 @@ fi
 workdir=''
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-}" ]] || [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-on}" =~ ^(true|on|1)$ ]] ; then
-  workdir="${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}"
+  workdir="$(expand_relative_volume_path "${BUILDKITE_PLUGIN_DOCKER_WORKDIR:-$workdir_default}")"
 fi
 
 # By default, mount $PWD onto $WORKDIR

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -214,6 +214,25 @@ setup() {
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with workdir with variables and option turned on" {
+  # shellcheck disable=2016  # we want the variable not interpreted now
+  export BUILDKITE_PLUGIN_DOCKER_WORKDIR='$ONE_VAR'
+  export BUILDKITE_PLUGIN_DOCKER_EXPAND_VOLUME_VARS=true
+  export BUILDKITE_COMMAND="pwd"
+
+  export ONE_VAR=/my/path
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/my/path --workdir /my/path --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND with devices" {
   export BUILDKITE_PLUGIN_DOCKER_WORKDIR=/app
   export BUILDKITE_PLUGIN_DOCKER_DEVICES_0=/dev/bus/usb/001/001


### PR DESCRIPTION
Adds workdir to the list of paths that are interpolated when `expand-volume-vars` is turned on.

Closes #259 