### PR TITLE
Add `chown` setting to fix root permissions on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Will propagate `GOOGLE_APPLICATION_CREDENTIALS`, `CLOUDSDK_AUTH_CREDENTIAL_FILE_
 
 Whether to match the user ID and group ID for the container user to the user ID and group ID for the host user. It is similar to specifying `user: 1000:1000`, except it avoids hardcoding a particular user/group ID.
 
-Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that Buildkite will be unable to remove, since containers by default run as the root user.
+Using this option ensures that any files created on shared mounts from within the container will be accessible to the host user. It is otherwise common to accidentally create root-owned files that the agent will be unable to remove, since a lot of images by default run as the root user. This can also be mitigated for the checkout directory by using the `chown` option of this plugin.
 
 ### `privileged` (optional, boolean)
 
@@ -318,6 +318,20 @@ Whether to automatically mount the current working directory which contains your
 If there's a git mirror path and `mount-checkout` is enabled, the (mirror path)[https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REPO_MIRROR] is mounted into the docker container as an added volume. Otherwise, the git mirror path will have to be explicitly added as an extra volume to mount into the container. 
 
 Default: `true`
+
+### `chown` (optional, boolean)
+
+Whether to `chown` the directory mounted with `mount-checkout` to the Buildkite agent user before exiting, to ensure that the agent can clean up any additional files created there. This will happen even if the command fails or is cancelled. This option has no effect on Windows or if `mount-checkout` is false.
+
+Prefer using `propagate-uid-gid` over this option, as the `chown`–which can take some time if your checkout is of considerable size—is likely not needed at all in that case.
+
+Default: `false`
+
+### `chown-image` (optional, string)
+
+The Docker image in which to run the `chown` command.
+
+Default: `busybox`
 
 ### `mount-buildkite-agent` (optional, boolean)
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,10 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
   for container in $(docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}") ; do
     echo "~~~ Cleaning up left-over container ${container}"
     docker stop "$container"
   done
+fi
+
+if ! is_windows && [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-true}" =~ ^(true|on|1)$ ]] && [[ "${BUILDKITE_PLUGIN_DOCKER_CHOWN:-false}" =~ ^(true|on|1)$ ]] ; then
+  docker run --rm -v "$PWD":"$PWD" "${BUILDKITE_PLUGIN_DOCKER_CHOWN_IMAGE:-busybox}" chown -Rh "$(id -u):$(id -g)" "$PWD"
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,6 +11,10 @@ configuration:
       type: array
     always-pull:
       type: boolean
+    chown:
+      type: boolean
+    chown-image:
+      type: string
     command:
       type: array
     cpus:

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+
+@test "Runs chown" {
+  export BUILDKITE_PLUGIN_DOCKER_CHOWN=true
+
+  stub docker \
+    "run --rm -v $PWD:$PWD busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  assert_output --partial "cleaned"
+
+  unstub docker
+}
+
+@test "Doesn't run if not configured" {
+  unset BUILDKITE_PLUGIN_DOCKER_CHOWN
+
+  stub docker \
+    "run --rm -v $PWD:$PWD busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  refute_output --partial "cleaned"
+
+  unstub docker || true
+}
+
+@test "Doesn't run if checkout not mounted" {
+  export BUILDKITE_PLUGIN_DOCKER_CHOWN=true
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT=false
+
+  stub docker \
+    "run --rm -v $PWD:$PWD busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  refute_output --partial "cleaned"
+
+  unstub docker || true
+}
+
+@test "Use custom image" {
+  export BUILDKITE_PLUGIN_DOCKER_CHOWN=true
+  export BUILDKITE_PLUGIN_DOCKER_CHOWN_IMAGE=some-image
+
+  stub docker \
+    "run --rm -v $PWD:$PWD some-image chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  assert_output --partial "cleaned"
+
+  unstub docker
+}


### PR DESCRIPTION
Implementation borrowed from [TeamCity](https://www.jetbrains.com/help/teamcity/cloud/container-wrapper.html#Restoring+File+Ownership+on+Linux)