### PR TITLE
Fix eval of exit code returned from docker image pull

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -350,7 +350,6 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${image}"
   if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \
        docker pull "${image}" ; then
-    local retry_exit_status="$?"
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -348,9 +348,8 @@ fi
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${image}"
-  retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" docker pull "${image}"
-  retry_exit_status="$?"
-  if [ $retry_exit_status -ne 0 ] ; then
+  retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" docker pull "${image}" || retry_exit_status="$?"
+  if [ ${retry_exit_status:-0} -ne 0 ] ; then
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -348,8 +348,9 @@ fi
 
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${image}"
-  if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \
-       docker pull "${image}" ; then
+  retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" docker pull "${image}"
+  retry_exit_status="$?"
+  if [ $retry_exit_status -ne 0 ] ; then
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -349,7 +349,7 @@ fi
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${image}"
   retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" docker pull "${image}" || retry_exit_status="$?"
-  if [ ${retry_exit_status:-0} -ne 0 ] ; then
+  if [ "${retry_exit_status:-0}" -ne 0 ] ; then
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -350,7 +350,7 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
   echo "--- :docker: Pulling ${image}"
   if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \
        docker pull "${image}" ; then
-    retry_exit_status="$?"
+    local retry_exit_status="$?"
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -8,7 +8,7 @@ function retry {
   local attempts=1
 
   until "$@"; do
-    retry_exit_status=$?
+    local retry_exit_status=$?
     echo "Exited with $retry_exit_status"
     if (( retries == "0" )); then
       return $retry_exit_status

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -91,11 +91,11 @@ setup() {
 
   stub docker \
     "pull image:tag" \
-    "pull image:tag"
+    "pull image:tag : exit 3"
 
   run "$PWD"/hooks/command
 
-  assert_failure
+  assert_failure 3
   assert_output --partial "Retrying 1 more times..."
   assert_output --partial "!!! :docker: Pull failed."
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -66,6 +66,42 @@ setup() {
   unstub docker
 }
 
+@test "Pull image first before running BUILDKITE_COMMAND, success on retries" {
+  export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
+  export BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES=2
+
+  stub docker \
+    "pull image:tag" \
+    "pull image:tag : echo pulled latest image on retry" \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Retrying 1 more times..."
+  assert_output --partial "pulled latest image on retry"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Pull image first before running BUILDKITE_COMMAND, failure on retries" {
+  export BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL=true
+  export BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES=2
+
+  stub docker \
+    "pull image:tag" \
+    "pull image:tag"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "Retrying 1 more times..."
+  assert_output --partial "!!! :docker: Pull failed."
+
+  unstub docker
+}
+
 @test "Runs BUILDKITE_COMMAND with mount-buildkite-agent disabled specifically" {
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
   export BUILDKITE_COMMAND="pwd"


### PR DESCRIPTION
Fix eval of returned exit status from `retry()` function.

Addresses: https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/279