### PR TITLE
Disable namespace remapping for chown cleanup

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -14,6 +14,6 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
 fi
 
 if ! is_windows && [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT:-true}" =~ ^(true|on|1)$ ]] && [[ "${BUILDKITE_PLUGIN_DOCKER_CHOWN:-false}" =~ ^(true|on|1)$ ]] ; then
-  docker run --rm -v "$PWD":"$PWD" "${BUILDKITE_PLUGIN_DOCKER_CHOWN_IMAGE:-busybox}" chown -Rh "$(id -u):$(id -g)" "$PWD"
+  docker run --rm -v "$PWD":"$PWD" --userns host "${BUILDKITE_PLUGIN_DOCKER_CHOWN_IMAGE:-busybox}" chown -Rh "$(id -u):$(id -g)" "$PWD"
 fi
 

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -6,7 +6,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_DOCKER_CHOWN=true
 
   stub docker \
-    "run --rm -v $PWD:$PWD busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+    "run --rm -v $PWD:$PWD --userns host busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
 
   run "$PWD"/hooks/pre-exit
 
@@ -20,7 +20,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_DOCKER_CHOWN
 
   stub docker \
-    "run --rm -v $PWD:$PWD busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+    "run --rm -v $PWD:$PWD --userns host busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
 
   run "$PWD"/hooks/pre-exit
 
@@ -35,7 +35,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_CHECKOUT=false
 
   stub docker \
-    "run --rm -v $PWD:$PWD busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+    "run --rm -v $PWD:$PWD --userns host busybox chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
 
   run "$PWD"/hooks/pre-exit
 
@@ -50,7 +50,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_DOCKER_CHOWN_IMAGE=some-image
 
   stub docker \
-    "run --rm -v $PWD:$PWD some-image chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
+    "run --rm -v $PWD:$PWD --userns host some-image chown -Rh $(id -u):$(id -g) $PWD : echo cleaned"
 
   run "$PWD"/hooks/pre-exit
 


### PR DESCRIPTION
This feature breaks our ability to effectively become root (by design).