### PR TITLE
Adding log driver opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "golang:1.11"
 ```
 
@@ -25,7 +25,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -37,7 +37,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -52,7 +52,7 @@ Note: If you are utilizing Buildkite's [Elastic CI Stack S3 Secrets plugin](http
 steps:
   - command: "yarn install; yarn run test"
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -84,7 +84,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -96,7 +96,7 @@ You can pass in additional volumes to be mounted. This is useful for running Doc
 steps:
   - command: "docker build . -t image:tag; docker push image:tag"
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -109,7 +109,7 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false
@@ -121,7 +121,7 @@ You can enable custom logging drivers and logging options with the use of `log-d
 steps:
   - command: "npm run start"
     plugins:
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "node:7"
           log-driver: "awslogs"
           log-opt:
@@ -144,7 +144,7 @@ steps:
           - "p"
           region: us-west-2
           no-include-email: true
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           image: "d.dkr.ecr.us-west-2.amazonaws.com/imagename"
           command: ["./run-integration-tests.sh"]
           expand-volume-vars: true
@@ -172,7 +172,7 @@ steps:
     plugins:
       - artifacts#v1.9.0:
           download: "node-7-image.tar.gz"
-      - docker#v5.13.0:
+      - docker#v5.12.0:
           load: "node-7-image.tar.gz"
           image: "node:7"
 ```
@@ -345,7 +345,7 @@ Specify a file to load a docker image from. If omitted no load will be done.
 
 Whether to automatically mount the current working directory which contains your checked out codebase. Mounts onto `/workdir`, unless `workdir` is set, in which case that will be used.
 
-If there's a git mirror path and `mount-checkout` is enabled, the (mirror path)[https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REPO_MIRROR] is mounted into the docker container as an added volume. Otherwise, the git mirror path will have to be explicitly added as an extra volume to mount into the container. 
+If there's a git mirror path and `mount-checkout` is enabled, the (mirror path)[https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REPO_MIRROR] is mounted into the docker container as an added volume. Otherwise, the git mirror path will have to be explicitly added as an extra volume to mount into the container.
 
 Default: `true`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ steps:
   - command: "go build -o dist/my-app ."
     artifact_paths: "./dist/my-app"
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "golang:1.11"
 ```
 
@@ -25,7 +25,7 @@ Windows images are also supported:
 steps:
   - command: "dotnet publish -c Release -o published"
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "microsoft/dotnet:latest"
           always-pull: true
 ```
@@ -37,7 +37,7 @@ If you want to control how your command is passed to the docker container, you c
 ```yml
 steps:
   - plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "mesosphere/aws-cli"
           always-pull: true
           command: ["s3", "sync", "s3://my-bucket/dist/", "/app/dist"]
@@ -52,7 +52,7 @@ Note: If you are utilizing Buildkite's [Elastic CI Stack S3 Secrets plugin](http
 steps:
   - command: "yarn install; yarn run test"
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "node:7"
           always-pull: true
           environment:
@@ -70,7 +70,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "node:7"
           always-pull: true
           propagate-environment: true
@@ -84,7 +84,7 @@ steps:
     env:
       MY_SPECIAL_BUT_PUBLIC_VALUE: kittens
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "node:7"
           always-pull: true
           propagate-aws-auth-tokens: true
@@ -96,7 +96,7 @@ You can pass in additional volumes to be mounted. This is useful for running Doc
 steps:
   - command: "docker build . -t image:tag; docker push image:tag"
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "docker:latest"
           always-pull: true
           volumes:
@@ -109,10 +109,26 @@ You can disable the default behaviour of mounting in the checkout to `workdir`:
 steps:
   - command: "npm start"
     plugins:
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "node:7"
           always-pull: true
           mount-checkout: false
+```
+
+You can enable custom logging drivers and logging options with the use of `log-driver` and `log-opt`:
+
+```yml
+steps:
+  - command: "npm run start"
+    plugins:
+      - docker#v5.13.0:
+          image: "node:7"
+          log-driver: "awslogs"
+          log-opt:
+            - "awslogs-group=my-buildkite-logs"
+            - "awslogs-region=us-east-1"
+            - "awslogs-stream-prefix=buildkite"
+            - "awslogs-create-group=true"
 ```
 
 Variable interpolation can be tricky due to the 3 layers involved (Buildkite, agent VM, and docker). For example, if you want to use [ECR Buildkite plugin](https://github.com/buildkite-plugins/ecr-buildkite-plugin), you will need to use the following syntax. Note the `$$` prefix for variables that would otherwise resolve at pipeline upload time, not runtime:
@@ -128,7 +144,7 @@ steps:
           - "p"
           region: us-west-2
           no-include-email: true
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           image: "d.dkr.ecr.us-west-2.amazonaws.com/imagename"
           command: ["./run-integration-tests.sh"]
           expand-volume-vars: true
@@ -156,7 +172,7 @@ steps:
     plugins:
       - artifacts#v1.9.0:
           download: "node-7-image.tar.gz"
-      - docker#v5.12.0:
+      - docker#v5.13.0:
           load: "node-7-image.tar.gz"
           image: "node:7"
 ```
@@ -306,6 +322,20 @@ Default: `true` for Linux and macOS, `false` for Windows.
 Whether or not to leave the container after the run, or immediately remove it with `--rm`.
 
 Default: `false`
+
+### `log-driver` (optional, string)
+
+The logging driver for the container. This allows you to configure how Docker handles logs for the container.
+
+Common drivers include: `json-file`, `syslog`, `journald`, `gelf`, `fluentd`, `awslogs`, `splunk`, `etwlogs`, `gcplogs`, `logentries`, `none`.
+
+Default: `json-file`
+
+See [Docker's logging documentation](https://docs.docker.com/config/containers/logging/) for complete details.
+
+### `log-opt` (optional, array)
+
+Options for the logging driver. These are key-value pairs that configure the behavior of the selected logging driver.
 
 ### `load` (optional, string)
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The logging driver for the container. This allows you to configure how Docker ha
 
 Common drivers include: `json-file`, `syslog`, `journald`, `gelf`, `fluentd`, `awslogs`, `splunk`, `etwlogs`, `gcplogs`, `logentries`, `none`.
 
-Default: `json-file`
+:information_source: As a default, Docker uses the [json-file logging driver](https://docs.docker.com/engine/logging/drivers/json-file/)
 
 See [Docker's logging documentation](https://docs.docker.com/config/containers/logging/) for complete details.
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -397,6 +397,18 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_STORAGE_OPT:-}" ]] ; then
   args+=("--storage-opt" "${BUILDKITE_PLUGIN_DOCKER_STORAGE_OPT:-}")
 fi
 
+# Support docker run --log-driver
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_LOG_DRIVER:-}" ]] ; then
+  args+=("--log-driver" "${BUILDKITE_PLUGIN_DOCKER_LOG_DRIVER}")
+fi
+
+# Support docker run --log-opt
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_LOG_OPT; then
+  for arg in "${result[@]}"; do
+    args+=("--log-opt" "$arg")
+  done
+fi
+
 shell=()
 shell_disabled=1
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -47,6 +47,10 @@ configuration:
       type: boolean
     load:
       type: string
+    log-driver:
+      type: string
+    log-opt:
+      type: array
     memory:
       type: string
     memory-swap:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1382,6 +1382,70 @@ EOF
   unstub docker
 }
 
+@test "Runs BUILDKITE_COMMAND with log-driver" {
+  export BUILDKITE_PLUGIN_DOCKER_LOG_DRIVER=json-file
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --log-driver json-file --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with log-opt" {
+  export BUILDKITE_PLUGIN_DOCKER_LOG_OPT_0=max-size=10m
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --log-opt max-size=10m --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with multiple log-opt" {
+  export BUILDKITE_PLUGIN_DOCKER_LOG_OPT_0=max-size=10m
+  export BUILDKITE_PLUGIN_DOCKER_LOG_OPT_1=max-file=3
+  export BUILDKITE_PLUGIN_DOCKER_LOG_OPT_2=labels=production
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --log-opt max-size=10m --log-opt max-file=3 --log-opt labels=production --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Runs BUILDKITE_COMMAND with log-driver and log-opt" {
+  export BUILDKITE_PLUGIN_DOCKER_LOG_DRIVER=syslog
+  export BUILDKITE_PLUGIN_DOCKER_LOG_OPT_0=syslog-address=tcp://192.168.1.3:514
+  export BUILDKITE_PLUGIN_DOCKER_LOG_OPT_1=tag=myapp
+  export BUILDKITE_COMMAND="echo hello world"
+
+  stub docker \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --log-driver syslog --log-opt syslog-address=tcp://192.168.1.3:514 --log-opt tag=myapp --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'echo hello world' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Run with BUILDKITE_COMMAND that exits with a failure" {
   export BUILDKITE_COMMAND='pwd'
 


### PR DESCRIPTION
Adding logging driver and logging options availability to the plugin.
This allows passing of custom `log-driver` and `log-opt`

For example: 

```yml
steps:
  - label: "Hello World"
    command: "echo 'Hello, world'"
    plugins:
      - docker#v5.13.0:
          image: "alpine:latest"
          log-driver: "json-file"
          log-opt:
            - "max-size=1m"
            - "max-file=2"
 ```

This Fixes: #284 

Also updates `README.md` to reflect changes and adds new unit tests.