### PR TITLE
SUP-4325: Include tracing variables into auto-propagate block for Docker plugin

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -276,6 +276,12 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_ENVIRONMENT:-false}" =~ ^(true|on|1)$
     while read -r var; do
       args+=( --env "${var%%=*}" )
     done < "$BUILDKITE_ENV_FILE"
+    
+    # Also ensure tracing variables are auto-propagated if they exist
+    [[ -n "${BUILDKITE_TRACING_BACKEND:-}" ]] && args+=( --env "BUILDKITE_TRACING_BACKEND" )
+    [[ -n "${BUILDKITE_TRACING_SERVICE_NAME:-}" ]] && args+=( --env "BUILDKITE_TRACING_SERVICE_NAME" )
+    [[ -n "${BUILDKITE_TRACING_PROPAGATE_TRACEPARENT:-}" ]] && args+=( --env "BUILDKITE_TRACING_PROPAGATE_TRACEPARENT" )
+    [[ -n "${BUILDKITE_TRACING_TRACEPARENT:-}" ]] && args+=( --env "BUILDKITE_TRACING_TRACEPARENT" )
   else
     echo -n "🚨 Not propagating environment variables to container as \$BUILDKITE_ENV_FILE is not set"
   fi


### PR DESCRIPTION
- Added tracing environment variables to the main auto-propagate section
- Tracing variables now propagate when `propagate-environment: true` is set
- Variables only propagate if they exist in the environment
- No impact when tracing is disabled
- Maintains backward compatibility