### PR TITLE
Fix Windows path handling for Docker volume mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,9 @@ Default: `busybox`
 
 Whether to automatically mount the `buildkite-agent` binary from the host agent machine into the container.
 
-Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X or Windows agent binary in a container running linux). If enabled in Windows agents your pipeline, step or agent **must have the `BUILDKITE_AGENT_BINARY_PATH` environment variable defined** with the executable to mount in the (Windows) agent.
+Set to `true` if you want to enable and are sure that the binary running in the agent is compatible with the container's architecture and environment (for example, don't try to mount the OS X or Windows agent binary in a container running linux).
+
+**Important:** When using Windows agents, you must define the `BUILDKITE_AGENT_BINARY_PATH` environment variable with the full path to the agent executable (for example, `C:\buildkite-agent.exe`).
 
 Default: `false`
 

--- a/tests/windows.bats
+++ b/tests/windows.bats
@@ -31,3 +31,45 @@ setup() {
   unstub docker
   unstub cmd.exe
 }
+
+@test "Run with backslash Windows agent path" {
+  export OSTYPE="win"
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=true
+  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_AGENT_BINARY_PATH="C:\\buildkite-agent.exe"
+
+  stub cmd.exe \
+    "//C $'echo %CD%' : echo WIN_PATH"
+
+  stub docker \
+    "run -i --rm --volume WIN_PATH:C:/workdir --workdir C:/workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume C:/buildkite-agent.exe:C:\\\\buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag CMD.EXE /c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unstub cmd.exe
+}
+
+@test "Run with double backslash Windows agent path" {
+  export OSTYPE="win"
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=true
+  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_AGENT_BINARY_PATH="C:\\\\buildkite-agent.exe"
+
+  stub cmd.exe \
+    "//C $'echo %CD%' : echo WIN_PATH"
+
+  stub docker \
+    "run -i --rm --volume WIN_PATH:C:/workdir --workdir C:/workdir --env BUILDKITE_JOB_ID --env BUILDKITE_BUILD_ID --env BUILDKITE_AGENT_ACCESS_TOKEN --volume C:/buildkite-agent.exe:C:\\\\buildkite-agent --label com.buildkite.job-id=1-2-3-4 image:tag CMD.EXE /c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+  unstub cmd.exe
+}


### PR DESCRIPTION
- Normalize backslashes to forward slashes in source paths for Docker compatibility
- Supports both Windows > Windows and Windows > Linux container scenarios
- Update documentation to clarify Windows agent requirements
- Add tests for single and double backslash path handling

Fixes: #256 