### PR TITLE
Add reuse-container mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,20 @@ Whether or not to leave the container after the run, or immediately remove it wi
 
 Default: `false`
 
+### `reuse-container` (optional, boolean)
+
+When set to `true`, the plugin keeps a named container running across pipeline steps instead of creating and destroying one each time. On each step, the plugin checks for an existing container: if the image digest matches, the command runs via `docker exec`; if the digest differs, the old container is removed and a fresh one is created. Environment variables are injected per-exec only (not baked into the container) to prevent secrets from leaking between jobs.
+
+The container name is derived from the image name and the agent's spawn index. If the agent name does not follow the `name-%spawn` convention, set `reuse-container-name` to avoid potential container name collisions between agents on the same host.
+
+Default: `false`
+
+### `reuse-container-name` (optional, string)
+
+Override the auto-generated container name used by the `reuse-container` feature. Use this when the default name derivation does not produce unique names (for example, when multiple agents on the same host do not use the standard `-%spawn` agent name suffix).
+
+Example: `my-build-container`
+
 ### `log-driver` (optional, string)
 
 The logging driver for the container. This allows you to configure how Docker handles logs for the container.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,22 @@ The container name is derived from the image name and the agent's spawn index. I
 
 Default: `false`
 
+#### Reuse safety and lifecycle
+
+A persistent container freezes its bind mounts and other create-time flags, so the plugin guards against reusing one that is no longer correct for the current job:
+
+- **Create-flag fingerprint.** At creation the container is labelled with a fingerprint of every flag frozen at container-creation time — volumes, `tmpfs`, `network`, devices, capabilities, resource limits, and so on — plus each bind-mount source's host inode. Flags that are re-applied on each `docker exec` (`-t`, `-i`, environment, `workdir`, `user`) and the per-job labels are excluded, since those can legitimately differ between jobs. Before reusing, the plugin recomputes the fingerprint and recreates the container if it differs. This catches two cases: a job whose create-time flags changed (for example a `tmpfs` mount that is now a bind `volume`, or a different `network`), and — importantly — a bind-mount source that was wiped and re-created on the host (for example a checkout that a failed `git clean` caused the agent to delete and re-clone). Without this, a reused container can run with the wrong mounts, and a stale bind mount makes every subsequent `docker exec` fail with `current working directory is outside of container mount namespace root ... possible container breakout detected` (exit 128). A container created before this feature (no fingerprint label) is treated as a mismatch and recreated once.
+
+- **Per-slot cleanup.** Persistent containers are labelled with `com.buildkite.docker-plugin.reuse=true` and the agent's spawn slot. At the start of every job (whether or not it uses `reuse-container`), the plugin discards this slot's persistent containers that the job does not need — a non-reuse job discards any leftover, and a reuse job discards any container other than the one it wants — so unused containers do not accumulate and exhaust host memory. Cleanup is scoped strictly to the agent's own spawn slot and is skipped when the agent name has no numeric `-%spawn` suffix (so it can never disturb another agent's container).
+
+- **Tainted marker.** A job running inside the container can opt the container out of reuse by creating the file `/var/run/buildkite-docker-reuse/tainted` (the plugin bind-mounts a fresh, world-writable host scratch dir there for each container). On the next job the plugin sees the marker and recreates the container instead of reusing it. This lets the job's own logic decide a container is no longer safe to reuse — for example a CI runner that detects an out-of-memory condition — without the plugin needing to interpret exit codes. Anything written into the `tainted` file is logged as the recreation reason.
+
+Notes and limitations:
+
+- Reuse safety applies on Unix agents; on Windows the fingerprint compares flags without bind-mount inode annotations.
+- The fingerprint covers create-time flags only (those frozen for the container's lifetime). Flags re-applied on each `docker exec` — TTY/interactive, environment, `workdir`, and `user` — are intentionally excluded, so changing them does not force a recreate.
+- The tainted-marker mechanism relies on the in-container job writing the marker; a job killed so abruptly that it cannot write the file will not mark the container as tainted (in which case the container is typically still healthy, and if its main process died it is recreated anyway).
+
 ### `reuse-container-name` (optional, string)
 
 Override the auto-generated container name used by the `reuse-container` feature. Use this when the default name derivation does not produce unique names (for example, when multiple agents on the same host do not use the standard `-%spawn` agent name suffix).

--- a/README.md
+++ b/README.md
@@ -341,11 +341,14 @@ A persistent container freezes its bind mounts and other create-time flags, so t
 
 - **Tainted marker.** A job running inside the container can opt the container out of reuse by creating the file `/var/run/buildkite-docker-reuse/tainted` (the plugin bind-mounts a fresh, world-writable host scratch dir there for each container). On the next job the plugin sees the marker and recreates the container instead of reusing it. This lets the job's own logic decide a container is no longer safe to reuse — for example a CI runner that detects an out-of-memory condition — without the plugin needing to interpret exit codes. Anything written into the `tainted` file is logged as the recreation reason.
 
+- **Job API socket.** The Buildkite Agent's Job API socket (`BUILDKITE_AGENT_JOB_API_SOCKET`, backing `buildkite-agent env`) lives at a per-job host path. In reuse mode the plugin therefore mounts the socket's stable **parent directory** (at the same path) rather than the per-job socket file: a directory bind mount is live, so each reused job sees its own current socket while the mount path stays constant, keeping the fingerprint stable and the Job API working on every job. (Mounting the per-job file instead would change the fingerprint every job, defeating reuse, and leave reused containers pinned to a stale socket.) The non-reuse path still mounts the single socket file. Note: this directory may also contain other concurrent jobs' Job API sockets on a shared agent host; access is gated by each job's `BUILDKITE_AGENT_JOB_API_TOKEN`, so a container can only use its own job's socket.
+
 Notes and limitations:
 
 - Reuse safety applies on Unix agents; on Windows the fingerprint compares flags without bind-mount inode annotations.
 - The fingerprint covers create-time flags only (those frozen for the container's lifetime). Flags re-applied on each `docker exec` — TTY/interactive, environment, `workdir`, and `user` — are intentionally excluded, so changing them does not force a recreate.
 - The tainted-marker mechanism relies on the in-container job writing the marker; a job killed so abruptly that it cannot write the file will not mark the container as tainted (in which case the container is typically still healthy, and if its main process died it is recreated anyway).
+- `mount-ssh-agent` uses `SSH_AUTH_SOCK`, a stable per-agent-session path, so it does not perturb the fingerprint across jobs on the same agent.
 
 ### `reuse-container-name` (optional, string)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -39,7 +39,8 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_INTERACTIVE:-$interactive_default}" =~ ^(true|o
   args+=("-i")
 fi
 
-if [[ ! "${BUILDKITE_PLUGIN_DOCKER_LEAVE_CONTAINER:-off}" =~ ^(true|on|1)$ ]] ; then
+if [[ ! "${BUILDKITE_PLUGIN_DOCKER_LEAVE_CONTAINER:-off}" =~ ^(true|on|1)$ ]] \
+   && [[ ! "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]] ; then
   args+=("--rm")
 fi
 
@@ -543,6 +544,11 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_RUN_LABELS:-true}" =~ ^(true|on|1)$ ]] ; then
   )
 fi
 
+# Snapshot run flags before image/shell/command for reuse-container mode.
+# These are pure "docker run" flags (volumes, env, network, etc.) without the
+# trailing image or command, which lets us reuse them for container creation.
+run_flags=("${args[@]}")
+
 # Add the image in before the shell and command
 args+=("${image}")
 
@@ -591,28 +597,137 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-echo "--- :docker: Running command in ${image}"
-echo -ne '\033[90m$\033[0m docker run ' >&2
+if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; then
+  # --- Reuse-container path ---
+  container_name=$(get_reuse_container_name "${image}")
 
-# Print all the arguments, with a space after, properly shell quoted
-printf "%q " "${args[@]}"
-echo
+  # Build exec_args by extracting only the flags that docker exec supports
+  # from the run_flags snapshot (tty, interactive, env, workdir, user).
+  exec_args=()
+  i=0
+  while [[ $i -lt ${#run_flags[@]} ]]; do
+    case "${run_flags[$i]}" in
+      -t|-i)
+        exec_args+=("${run_flags[$i]}")
+        ;;
+      --env|--env-file|--workdir|-u)
+        exec_args+=("${run_flags[$i]}" "${run_flags[$((i+1))]}")
+        i=$((i+1))
+        ;;
+    esac
+    i=$((i+1))
+  done
 
-# Disable -e outside of the subshell; since the subshell returning a failure
-# would exit the parent shell (here) early.
-set +e
+  # Build the command to execute inside the container
+  exec_cmd=()
+  if [[ ${#shell[@]} -gt 0 ]]; then
+    for shell_arg in "${shell[@]}"; do
+      exec_cmd+=("$shell_arg")
+    done
+  fi
+  if [[ -n "${BUILDKITE_COMMAND}" ]]; then
+    if is_windows; then
+      windows_multi_command=${BUILDKITE_COMMAND//$'\n'/ && }
+      exec_cmd+=("${windows_multi_command}")
+    else
+      exec_cmd+=("${BUILDKITE_COMMAND}")
+    fi
+  elif [[ ${#command[@]} -gt 0 ]]; then
+    for command_arg in "${command[@]}"; do
+      exec_cmd+=("$command_arg")
+    done
+  fi
 
-# Prevent SIGTERM from killing this script. SIGTERM will still be passed to the Docker container, which can exit
-# gracefully (or, if necessary, non-gracefully per the `--stop-timeout` flag passed above).
-trap '' SIGTERM
+  need_create=true
 
-# Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
-# See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.
-# `trap` is used in this subshell for the same reason it is used above.
-( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && trap '' SIGTERM && docker run "${args[@]}" )
+  # Check if container already exists
+  container_running=$(docker container inspect --format '{{.State.Running}}' "${container_name}" 2>/dev/null || true)
 
-exit_code=$?
+  if [[ "${container_running}" == "true" ]]; then
+    container_image_id=$(get_container_image_id "${container_name}")
+    expected_image_id=$(get_image_id "${image}")
+    if [[ -n "${expected_image_id}" ]] && [[ "${container_image_id}" == "${expected_image_id}" ]]; then
+      echo "--- :docker: Reusing existing container ${container_name} (${image})"
+      need_create=false
+    else
+      echo "+++ WARNING: Container image mismatch for ${container_name}"
+      echo "    Expected image: ${image} (${expected_image_id:-unknown})"
+      echo "    Container image ID: ${container_image_id:-unknown}"
+      echo "    Removing old container and creating a new one."
+      docker rm -f "${container_name}"
+    fi
+  elif [[ -n "${container_running}" ]]; then
+    echo "--- :docker: Removing stopped container ${container_name}"
+    docker rm -f "${container_name}"
+  fi
 
-set -e
+  if [[ "${need_create}" == "true" ]]; then
+    # Strip --env and --env-file from run_flags for the creation run.
+    # The detached container only runs "sleep infinity" and needs no env vars.
+    # All job env vars are injected per-exec to avoid leaking secrets from
+    # one job's environment into subsequent jobs that reuse the container.
+    create_flags=()
+    i=0
+    while [[ $i -lt ${#run_flags[@]} ]]; do
+      case "${run_flags[$i]}" in
+        --env|--env-file)
+          i=$((i+1))
+          ;;
+        *)
+          create_flags+=("${run_flags[$i]}")
+          ;;
+      esac
+      i=$((i+1))
+    done
 
-exit $exit_code  # propagate exit code
+    echo "--- :docker: Creating persistent container ${container_name} (${image})"
+    echo -ne '\033[90m$\033[0m docker run -d --name ' >&2
+    echo -n "${container_name} " >&2
+    printf "%q " "${create_flags[@]}" >&2
+    echo "--entrypoint '' ${image} sleep infinity" >&2
+
+    docker run -d --name "${container_name}" "${create_flags[@]}" \
+      --entrypoint "" "${image}" sleep infinity >/dev/null
+  fi
+
+  echo "--- :docker: Executing command in container ${container_name}"
+  echo -ne '\033[90m$\033[0m docker exec ' >&2
+  printf "%q " "${exec_args[@]}" "${container_name}" "${exec_cmd[@]}" >&2
+  echo >&2
+
+  set +e
+  trap '' SIGTERM
+  ( if is_windows; then export MSYS_NO_PATHCONV=1; fi && trap '' SIGTERM && docker exec "${exec_args[@]}" "${container_name}" "${exec_cmd[@]}" )
+
+  exit_code=$?
+  set -e
+  exit $exit_code
+
+else
+  # --- Normal path ---
+  echo "--- :docker: Running command in ${image}"
+  echo -ne '\033[90m$\033[0m docker run ' >&2
+
+  # Print all the arguments, with a space after, properly shell quoted
+  printf "%q " "${args[@]}"
+  echo
+
+  # Disable -e outside of the subshell; since the subshell returning a failure
+  # would exit the parent shell (here) early.
+  set +e
+
+  # Prevent SIGTERM from killing this script. SIGTERM will still be passed to the Docker container, which can exit
+  # gracefully (or, if necessary, non-gracefully per the `--stop-timeout` flag passed above).
+  trap '' SIGTERM
+
+  # Don't convert paths on gitbash on windows, as that can mangle user paths and cmd options.
+  # See https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/81 for more information.
+  # `trap` is used in this subshell for the same reason it is used above.
+  ( if is_windows ; then export MSYS_NO_PATHCONV=1; fi && trap '' SIGTERM && docker run "${args[@]}" )
+
+  exit_code=$?
+
+  set -e
+
+  exit $exit_code
+fi

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -597,9 +597,52 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
+# Constants shared by the reuse-container path. The tainted dir is a fixed
+# contract between this plugin and the in-container job (e.g. Cinder), not a
+# user-facing option: a job touches "${reuse_tainted_target}/tainted" to opt its
+# container out of reuse. The host base is overridable only via an internal env
+# var so tests can redirect it away from the real /var/tmp.
+reuse_tainted_target="/var/run/buildkite-docker-reuse"
+reuse_tainted_base="${BUILDKITE_PLUGIN_DOCKER_REUSE_TAINTED_BASE:-/var/tmp/buildkite-docker-reuse}"
+
+# Discard persistent reuse containers from previous jobs that this job does not
+# need, scoped to this agent's spawn slot. Runs for both reuse and non-reuse
+# jobs (a non-reuse job should not leave a stale persistent container hogging
+# memory), but only when a numeric spawn slot is determinable -- otherwise we
+# cannot safely tell this agent's containers apart from another agent's.
+if ! is_windows ; then
+  reuse_spawn_slot="$(get_spawn_slot)"
+  if [[ -n "${reuse_spawn_slot}" ]]; then
+    keep_container=""
+    if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; then
+      keep_container="$(get_reuse_container_name "${image}")"
+    fi
+    cleanup_foreign_reuse_containers "${reuse_spawn_slot}" "${keep_container}"
+  fi
+fi
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; then
   # --- Reuse-container path ---
   container_name=$(get_reuse_container_name "${image}")
+
+  # Enforce Docker's container-name rules before deriving any host path from the
+  # name. This rejects path-traversal values (e.g. an explicit reuse-container-
+  # name of ".." or "a/b") that would otherwise make the "rm -rf" of the tainted
+  # scratch dir below operate outside its base.
+  if [[ ! "${container_name}" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]]; then
+    echo "+++ Error: Invalid reuse container name '${container_name}'." >&2
+    echo "    Must match Docker's naming rules: ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$" >&2
+    exit 1
+  fi
+
+  host_tainted_dir="${reuse_tainted_base}/${container_name}"
+
+  # Fingerprint of this job's create-time flags (+ bind-mount source inodes).
+  # Used to detect, before reuse, both a flag mismatch (e.g. a changed tmpfs,
+  # volume, network, ...) and a wiped/re-created bind-mount source (the stale-
+  # mount breakout). Computed from run_flags, excluding per-exec flags, labels,
+  # and the internal tainted-marker mount.
+  current_fingerprint="$(compute_reuse_fingerprint "${reuse_tainted_target}" "${run_flags[@]}")"
 
   # Build exec_args by extracting only the flags that docker exec supports
   # from the run_flags snapshot (tty, interactive, env, workdir, user).
@@ -649,6 +692,31 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; t
     if [[ -n "${expected_image_id}" ]] && [[ "${container_image_id}" == "${expected_image_id}" ]]; then
       echo "--- :docker: Reusing existing container ${container_name} (${image})"
       need_create=false
+
+      # Compare the create-flag fingerprint stamped at creation against this
+      # job's. A difference means either a create-time flag changed (mismatch,
+      # e.g. a tmpfs/volume/network change) or a bind-mount source was wiped and
+      # re-created on the host (staleness, e.g. a re-cloned checkout). The latter
+      # is the breakout that fails every subsequent `docker exec --workdir` with
+      # "current working directory is outside of container mount namespace root"
+      # (exit 128). A missing/empty label (a container from before this feature)
+      # is treated as a mismatch.
+      stored_fingerprint="$(docker inspect --format '{{ index .Config.Labels "com.buildkite.docker-plugin.fingerprint" }}' "${container_name}" 2>/dev/null || true)"
+      if [[ "${stored_fingerprint}" != "${current_fingerprint}" ]]; then
+        echo "+++ :docker: Create-flag fingerprint changed for ${container_name}; recreating container"
+        echo "    (a create-time flag changed, or a bind-mount source was wiped and re-created on the host)"
+        docker rm -f "${container_name}" >/dev/null 2>&1 || true
+        need_create=true
+      # Honor an out-of-band tainted marker written by the in-container job (e.g.
+      # Cinder's error analysis on OOM) to opt this container out of reuse.
+      elif [[ -f "${host_tainted_dir}/tainted" ]]; then
+        echo "+++ :docker: Container ${container_name} is tainted; recreating container"
+        if [[ -s "${host_tainted_dir}/tainted" ]]; then
+          echo "    reason: $(tr -d '\n' < "${host_tainted_dir}/tainted")"
+        fi
+        docker rm -f "${container_name}" >/dev/null 2>&1 || true
+        need_create=true
+      fi
     else
       echo "+++ WARNING: Container image mismatch for ${container_name}"
       echo "    Expected image: ${image} (${expected_image_id:-unknown})"
@@ -679,6 +747,27 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; t
       esac
       i=$((i+1))
     done
+
+    # Discovery + fingerprint labels. The reuse/spawn-slot labels let later jobs
+    # find and scope-clean this slot's containers; the fingerprint records the
+    # create-time flags (+ inodes) this container was built with. Labels are
+    # excluded from the fingerprint, so adding them here does not perturb it.
+    create_flags+=("--label" "com.buildkite.docker-plugin.reuse=true")
+    if [[ -n "${reuse_spawn_slot:-}" ]]; then
+      create_flags+=("--label" "com.buildkite.docker-plugin.spawn-slot=${reuse_spawn_slot}")
+    fi
+    create_flags+=("--label" "com.buildkite.docker-plugin.fingerprint=${current_fingerprint}")
+
+    # Out-of-band tainted-marker channel: a fresh, per-container host scratch dir bind-
+    # mounted into the container. Reset on every creation so a new container
+    # never inherits a stale marker, and world-writable so the in-container job
+    # (which may run as a different uid) can create the marker file. Unix only.
+    if ! is_windows ; then
+      rm -rf "${host_tainted_dir}"
+      mkdir -p "${host_tainted_dir}"
+      chmod 0777 "${host_tainted_dir}"
+      create_flags+=("--volume" "${host_tainted_dir}:${reuse_tainted_target}")
+    fi
 
     echo "--- :docker: Creating persistent container ${container_name} (${image})"
     echo -ne '\033[90m$\033[0m docker run -d --name ' >&2

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -725,7 +725,7 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; t
       if [[ "${stored_fingerprint}" != "${current_fingerprint}" ]]; then
         echo "+++ :docker: Create-flag fingerprint changed for ${container_name}; recreating container"
         echo "    (a create-time flag changed, or a bind-mount source was wiped and re-created on the host)"
-        docker rm -f "${container_name}" >/dev/null 2>&1 || true
+        remove_reuse_container "${container_name}" || fail_reuse_cleanup "${container_name}"
         need_create=true
       # Honor an out-of-band tainted marker written by the in-container job (e.g.
       # Cinder's error analysis on OOM) to opt this container out of reuse.
@@ -734,7 +734,7 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; t
         if [[ -s "${host_tainted_dir}/tainted" ]]; then
           echo "    reason: $(tr -d '\n' < "${host_tainted_dir}/tainted")"
         fi
-        docker rm -f "${container_name}" >/dev/null 2>&1 || true
+        remove_reuse_container "${container_name}" || fail_reuse_cleanup "${container_name}"
         need_create=true
       fi
     else
@@ -742,11 +742,11 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]]; t
       echo "    Expected image: ${image} (${expected_image_id:-unknown})"
       echo "    Container image ID: ${container_image_id:-unknown}"
       echo "    Removing old container and creating a new one."
-      docker rm -f "${container_name}"
+      remove_reuse_container "${container_name}" || fail_reuse_cleanup "${container_name}"
     fi
   elif [[ -n "${container_running}" ]]; then
     echo "--- :docker: Removing stopped container ${container_name}"
-    docker rm -f "${container_name}"
+    remove_reuse_container "${container_name}" || fail_reuse_cleanup "${container_name}"
   fi
 
   if [[ "${need_create}" == "true" ]]; then

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -250,8 +250,28 @@ if [[ -n "${BUILDKITE_AGENT_JOB_API_SOCKET:-}" ]] ; then
   args+=(
     "--env" "BUILDKITE_AGENT_JOB_API_SOCKET"
     "--env" "BUILDKITE_AGENT_JOB_API_TOKEN"
-    "--volume" "$BUILDKITE_AGENT_JOB_API_SOCKET:$BUILDKITE_AGENT_JOB_API_SOCKET"
   )
+  if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]] ; then
+    # Reuse containers are long-lived, but the Job API socket lives at a
+    # per-job host path. Mounting the per-job socket file would (a) make the
+    # create-flag fingerprint differ every job, forcing a recreate and
+    # defeating reuse, and (b) leave the reused container pinned to a stale,
+    # closed socket. Instead mount the socket's stable parent directory: a
+    # directory bind mount is live, so each reused job sees its own current
+    # socket (and the agent's cleanup of old ones), the fingerprint stays
+    # stable, and the Job API works on every job.
+    #
+    # Security: this directory can also hold other concurrent jobs' Job API
+    # sockets on a shared agent host. Use is gated by each job's
+    # BUILDKITE_AGENT_JOB_API_TOKEN (a container only holds its own job's
+    # token), and the mount must be read-write because connecting to a unix
+    # domain socket requires write access. Mount only the job-api directory,
+    # never a broader parent.
+    job_api_dir="${BUILDKITE_AGENT_JOB_API_SOCKET%/*}"
+    args+=( "--volume" "${job_api_dir}:${job_api_dir}" )
+  else
+    args+=( "--volume" "$BUILDKITE_AGENT_JOB_API_SOCKET:$BUILDKITE_AGENT_JOB_API_SOCKET" )
+  fi
 fi
 
 # Parse extra env vars and add them to the docker args

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -6,7 +6,9 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 . "$DIR/../lib/shared.bash"
 
-if [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
+if [[ "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER:-false}" =~ ^(true|on|1)$ ]] ; then
+  echo "~~~ Skipping container cleanup (reuse-container is enabled)"
+elif [[ "${BUILDKITE_PLUGIN_DOCKER_CLEANUP:-true}" =~ ^(true|on|1)$ ]] ; then
   for container in $(docker ps -a -q --filter "label=com.buildkite.job-id=${BUILDKITE_JOB_ID}") ; do
     echo "~~~ Cleaning up left-over container ${container}"
     docker stop "$container"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -76,3 +76,41 @@ function is_macos() {
   [[ "$OSTYPE" =~ ^(darwin) ]]
 }
 
+# Returns a stable container name for the reuse-container feature.
+# Uses the explicit override if set, otherwise derives from the image name
+# and the agent's spawn index (to isolate containers per agent on a host).
+function get_reuse_container_name() {
+  local image="$1"
+
+  if [[ -n "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER_NAME:-}" ]]; then
+    echo "${BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER_NAME}"
+    return
+  fi
+
+  local sanitized="${image//[^a-zA-Z0-9_.-]/-}"
+  local name="${sanitized}"
+
+  local spawn_suffix="${BUILDKITE_AGENT_NAME##*-}"
+  if [[ "${spawn_suffix}" =~ ^[0-9]+$ ]]; then
+    name="${name}-${spawn_suffix}"
+  else
+    echo "Warning: Could not extract numeric spawn index from BUILDKITE_AGENT_NAME '${BUILDKITE_AGENT_NAME}'." >&2
+    echo "  Multiple agents on the same host may share container name '${name}'." >&2
+    echo "  Set 'reuse-container-name' to specify an explicit container name." >&2
+  fi
+
+  echo "${name}"
+}
+
+# Returns the image ID (digest) of the image a container was created from.
+function get_container_image_id() {
+  local container_name="$1"
+  docker inspect --format '{{.Image}}' "${container_name}" 2>/dev/null
+}
+
+# Returns the image ID (digest) of a local image.
+function get_image_id() {
+  local image="$1"
+  docker image inspect --format '{{.Id}}' "${image}" 2>/dev/null
+}
+

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -76,6 +76,19 @@ function is_macos() {
   [[ "$OSTYPE" =~ ^(darwin) ]]
 }
 
+# Returns the agent's numeric spawn index (the trailing "-N" of
+# BUILDKITE_AGENT_NAME), or nothing if it cannot be determined. This is the
+# per-slot key that scopes reuse containers and their cleanup to one agent on a
+# shared host. Computed from BUILDKITE_AGENT_NAME directly so it stays correct
+# even when an explicit reuse-container-name is used.
+function get_spawn_slot() {
+  local agent_name="${BUILDKITE_AGENT_NAME:-}"
+  local spawn_suffix="${agent_name##*-}"
+  if [[ "${spawn_suffix}" =~ ^[0-9]+$ ]]; then
+    echo "${spawn_suffix}"
+  fi
+}
+
 # Returns a stable container name for the reuse-container feature.
 # Uses the explicit override if set, otherwise derives from the image name
 # and the agent's spawn index (to isolate containers per agent on a host).
@@ -90,16 +103,124 @@ function get_reuse_container_name() {
   local sanitized="${image//[^a-zA-Z0-9_.-]/-}"
   local name="${sanitized}"
 
-  local spawn_suffix="${BUILDKITE_AGENT_NAME##*-}"
-  if [[ "${spawn_suffix}" =~ ^[0-9]+$ ]]; then
+  local spawn_suffix
+  spawn_suffix="$(get_spawn_slot)"
+  if [[ -n "${spawn_suffix}" ]]; then
     name="${name}-${spawn_suffix}"
   else
-    echo "Warning: Could not extract numeric spawn index from BUILDKITE_AGENT_NAME '${BUILDKITE_AGENT_NAME}'." >&2
+    echo "Warning: Could not extract numeric spawn index from BUILDKITE_AGENT_NAME '${BUILDKITE_AGENT_NAME:-}'." >&2
     echo "  Multiple agents on the same host may share container name '${name}'." >&2
     echo "  Set 'reuse-container-name' to specify an explicit container name." >&2
   fi
 
   echo "${name}"
+}
+
+# Returns the inode number of a host path, portably across GNU and BSD/macOS
+# (avoids the GNU-only `stat -c %i`). Prints "missing" when the path does not
+# exist, which still yields a deterministic, comparable fingerprint entry.
+function get_host_inode() {
+  local path="$1"
+  if [[ -e "${path}" ]]; then
+    # `ls -d -i` prints "<inode> <path>" for the path itself (not contents).
+    # shellcheck disable=SC2012  # `find -printf` is GNU-only; ls keeps this
+    # portable to BSD/macOS, and we only read the leading inode field.
+    ls -di "${path}" 2>/dev/null | awk '{print $1}'
+  else
+    echo "missing"
+  fi
+}
+
+# Computes a deterministic fingerprint of the create-time flags a reuse
+# container is (re)created with, so a later job can detect when it would reuse a
+# container that was built with different flags (mismatch) or with a bind-mount
+# source that has since been wiped and re-created on the host (staleness, e.g. a
+# re-cloned checkout). This covers EVERY flag frozen at container creation
+# (volumes, tmpfs, network, devices, caps, resources, etc.), so changing any of
+# them forces a fresh container.
+#
+# Excluded (deliberately):
+#   - flags re-applied on each `docker exec` and therefore allowed to differ
+#     between jobs without a recreate: -t, -i, --env, --env-file, --workdir, -u;
+#   - all --label values (volatile per-job metadata and the plugin's own labels);
+#   - the plugin-internal tainted-marker --volume (identified by <tainted_target>).
+# For each remaining bind-mount --volume the host source inode is appended
+# (absolute source, Unix only) so a wiped/re-created source is detected.
+#
+# Flags are kept in their (deterministic) build order and joined with ",". The
+# raw string is returned (not hashed) to avoid depending on sha256sum vs shasum.
+#
+# Usage: compute_reuse_fingerprint <tainted_target> <flag>...
+function compute_reuse_fingerprint() {
+  local tainted_target="$1"; shift
+  local -a flags=("$@")
+  local -a entries=()
+  local i=0
+
+  while [[ $i -lt ${#flags[@]} ]]; do
+    local flag="${flags[$i]}"
+    case "${flag}" in
+      -t|-i)
+        # Per-exec flag (no value); not frozen.
+        ;;
+      --workdir|-u|--env|--env-file|--label)
+        # Per-exec or volatile; skip the flag and its value.
+        i=$((i+1))
+        ;;
+      --volume)
+        local spec="${flags[$((i+1))]}"
+        i=$((i+1))
+        local rest="${spec#*:}"
+        local dst="${rest%%:*}"
+        if [[ -n "${tainted_target}" && "${dst}" == "${tainted_target}" ]]; then
+          : # plugin-internal tainted-marker mount; not part of user config
+        else
+          local src="${spec%%:*}"
+          if [[ "${src}" == /* ]] && ! is_windows; then
+            entries+=("--volume=${spec}#$(get_host_inode "${src}")")
+          else
+            entries+=("--volume=${spec}")
+          fi
+        fi
+        ;;
+      *)
+        # Any other create-time flag (or a value token of one): keep verbatim,
+        # in order, so it contributes to the fingerprint.
+        entries+=("${flag}")
+        ;;
+    esac
+    i=$((i+1))
+  done
+
+  if [[ ${#entries[@]} -gt 0 ]]; then
+    local IFS=','
+    echo "${entries[*]}"
+  fi
+}
+
+# Removes persistent reuse containers belonging to this agent's spawn slot that
+# this job does not need, freeing their memory. Scoped per slot via labels so it
+# never touches another agent's container on a shared host.
+#   <slot>  the agent spawn slot (from get_spawn_slot).
+#   <keep>  the one container name to preserve (the desired reuse container for
+#           this job); pass "" for non-reuse jobs to discard all slot containers.
+function cleanup_foreign_reuse_containers() {
+  local slot="$1" keep="$2"
+  local names
+  names="$(docker ps -a \
+    --filter "label=com.buildkite.docker-plugin.reuse=true" \
+    --filter "label=com.buildkite.docker-plugin.spawn-slot=${slot}" \
+    --format '{{.Names}}' 2>/dev/null || true)"
+
+  [[ -z "${names}" ]] && return 0
+
+  local name
+  while IFS= read -r name; do
+    [[ -z "${name}" ]] && continue
+    [[ -n "${keep}" && "${name}" == "${keep}" ]] && continue
+    echo "--- :docker: Discarding persistent container ${name} (not needed by this job on slot ${slot})"
+    docker rm -f "${name}" >/dev/null 2>&1 || true
+  done <<< "${names}"
 }
 
 # Returns the image ID (digest) of the image a container was created from.

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -219,7 +219,7 @@ function cleanup_foreign_reuse_containers() {
     [[ -z "${name}" ]] && continue
     [[ -n "${keep}" && "${name}" == "${keep}" ]] && continue
     echo "--- :docker: Discarding persistent container ${name} (not needed by this job on slot ${slot})"
-    docker rm -f "${name}" >/dev/null 2>&1 || true
+    rm_reuse_container_logged "${name}" || true
   done <<< "${names}"
 }
 
@@ -233,5 +233,85 @@ function get_container_image_id() {
 function get_image_id() {
   local image="$1"
   docker image inspect --format '{{.Id}}' "${image}" 2>/dev/null
+}
+
+# Force-removes a container and logs the REAL error on failure instead of
+# swallowing it. `docker rm -f` failures were previously always redirected to
+# /dev/null, so production has never once shown why a removal actually failed
+# (a slow-but-eventual async teardown vs. a permanently stuck mount vs.
+# something else) -- every occurrence of this bug has only ever been diagnosed
+# from the downstream "name already in use" symptom on the next `docker run`.
+# Returns docker rm's exit code; "No such container" is treated as success
+# (0) since the name is already free.
+function rm_reuse_container_logged() {
+  local name="$1"
+  local out rc
+  out="$(docker rm -f "${name}" 2>&1)"
+  rc=$?
+  [[ "${rc}" -eq 0 ]] && return 0
+  [[ "${out}" == *"No such container"* ]] && return 0
+  echo "--- :docker: 'docker rm -f ${name}' failed (exit ${rc}): ${out}" >&2
+  return "${rc}"
+}
+
+# Robustly free a reuse container's NAME so a fresh container can be created
+# under the same name. Replaces a plain `docker rm -f ... >/dev/null 2>&1 || true`
+# which silently ignored removal failures and then let `docker run --name` die
+# with a cryptic "name is already in use" (exit 125).
+#
+# Docker can leave a container wedged in "Removal In Progress"/"Dead" (e.g. busy
+# mounts left by an in-container build, or a bind-mount source wiped on the host);
+# the name stays reserved until removal actually completes (moby/moby#37698 and
+# related). So we force-remove, then VERIFY the name is gone via `docker container
+# inspect`, retrying removal with a short backoff until it is free or the attempt
+# budget is exhausted. Every attempt logs the real docker error on failure
+# (rm_reuse_container_logged), instead of the previous `|| true` that discarded it.
+#
+# Returns 0 when the name is free, non-zero when it could not be freed.
+# The attempt budget and delay are overridable via env (used by tests).
+function remove_reuse_container() {
+  local name="$1"
+  local attempts="${REUSE_RM_VERIFY_ATTEMPTS:-10}"
+  local sleep_secs="${REUSE_RM_VERIFY_SLEEP:-1}"
+  local i
+
+  rm_reuse_container_logged "${name}"
+  if ! docker container inspect "${name}" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "--- :docker: ${name} still registered after 'docker rm -f'; waiting for release" >&2
+
+  # Poll + retry: a container can sit in "Removal In Progress"/"Dead" while a
+  # busy mount clears. Re-attempt removal until the name is free or we give up.
+  for (( i=1; i<=attempts; i++ )); do
+    sleep "${sleep_secs}"
+    if ! docker container inspect "${name}" >/dev/null 2>&1; then
+      return 0
+    fi
+    rm_reuse_container_logged "${name}"
+  done
+
+  # Final verdict: success iff the name is now free. `!` also exempts this from
+  # `set -e` so the caller receives the return value.
+  ! docker container inspect "${name}" >/dev/null 2>&1
+}
+
+# Abort the job with a distinct, greppable failure signature when a reuse
+# container's name cannot be freed for recreation. Failing here (instead of
+# letting `docker run --name` throw a cryptic exit 125) gives a clear,
+# machine-detectable reason that Error Analysis / auto-retry can key on to retry
+# the job on a clean host. The "REUSE_CONTAINER_CLEANUP_FAILED" marker is a
+# stable contract; do not reword it without updating downstream matchers.
+function fail_reuse_cleanup() {
+  local name="$1"
+  echo "+++ :docker: 🚨 REUSE_CONTAINER_CLEANUP_FAILED" >&2
+  echo "    Could not remove the existing reuse container '${name}', so it cannot be" >&2
+  echo "    recreated under the same name. The container is likely wedged" >&2
+  echo "    ('Removal In Progress'/'Dead', e.g. from busy mounts or a wiped bind-mount" >&2
+  echo "    source). Failing intentionally instead of dying on a cryptic 'name already" >&2
+  echo "    in use' error. This is an environmental failure and is safe to retry." >&2
+  echo "    Container state:" >&2
+  docker ps -a --filter "name=^/${name}$" --format '      {{.ID}} {{.Image}} {{.Status}} {{.Names}}' >&2 2>/dev/null || true
+  exit 125
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -107,6 +107,10 @@ configuration:
       type: boolean
     privileged:
       type: boolean
+    reuse-container:
+      type: boolean
+    reuse-container-name:
+      type: string
     publish:
       type: array
     init:

--- a/tests/reuse-container.bats
+++ b/tests/reuse-container.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+
+# Uncomment to enable stub debug output:
+# export DOCKER_STUB_DEBUG=/dev/tty
+
+setup() {
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE=image:tag
+  export BUILDKITE_JOB_ID="1-2-3-4"
+  export BUILDKITE_PLUGIN_DOCKER_CLEANUP=false
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_PLUGIN_DOCKER_RUN_LABELS="false"
+  export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER=true
+  export BUILDKITE_AGENT_NAME="builder-3"
+}
+
+@test "Reuse container: creates new container when none exists" {
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Creating persistent container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: exec into existing container with matching image digest" {
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Reusing existing container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: replaces container on image digest mismatch" {
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:olddigest" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:newdigest" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "WARNING: Container image mismatch"
+  assert_output --partial "Expected image: image:tag (sha256:newdigest)"
+  assert_output --partial "Container image ID: sha256:olddigest"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: removes and recreates stopped container" {
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo false" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Removing stopped container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: uses custom container name" {
+  export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER_NAME="my-custom-container"
+
+  stub docker \
+    "container inspect --format '{{.State.Running}}' my-custom-container : exit 1" \
+    "run -d --name my-custom-container -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir my-custom-container /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Creating persistent container my-custom-container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: omits spawn index when agent name has no numeric suffix" {
+  export BUILDKITE_AGENT_NAME="solo-agent"
+
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag : exit 1" \
+    "run -d --name image-tag -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Warning: Could not extract numeric spawn index"
+  assert_output --partial "Creating persistent container image-tag"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: passes environment variables to exec" {
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=OTHER=thing
+
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "exec -t -i --workdir /workdir --env MY_TAG=value --env OTHER=thing image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: env vars stripped from creation but passed to exec" {
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_0=MY_TAG=value
+  export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=SECRET=supersecret
+
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir --env MY_TAG=value --env SECRET=supersecret image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: pre-exit skips cleanup" {
+  export BUILDKITE_PLUGIN_DOCKER_CLEANUP=true
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  assert_output --partial "Skipping container cleanup (reuse-container is enabled)"
+}
+
+@test "Reuse container: no --rm flag in docker run args" {
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  refute_output --partial -- "--rm"
+
+  unstub docker
+}
+
+@test "Reuse container: propagates exec exit code on failure" {
+  stub docker \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : exit 42"
+
+  run "$PWD"/hooks/command
+
+  assert_failure 42
+
+  unstub docker
+}

--- a/tests/reuse-container.bats
+++ b/tests/reuse-container.bats
@@ -29,6 +29,9 @@ setup() {
 
 teardown() {
   rm -rf "${TAINTED_BASE}"
+  if [[ -n "${JOBAPI_DIR:-}" ]]; then
+    rm -rf "${JOBAPI_DIR}"
+  fi
 }
 
 @test "Reuse container: creates new container when none exists" {
@@ -124,6 +127,72 @@ teardown() {
 
   assert_success
   assert_output --partial "Create-flag fingerprint changed"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: mounts the Job API socket directory (not the file) on create" {
+  JOBAPI_DIR="$(mktemp -d)"
+  export BUILDKITE_AGENT_JOB_API_SOCKET="${JOBAPI_DIR}/3760-27802.sock"
+  export BUILDKITE_AGENT_JOB_API_TOKEN="tok"
+  local jfp="--init,--volume=${PWD}:/workdir#$(ls -di "$PWD" | awk '{print $1}'),--volume=${JOBAPI_DIR}:${JOBAPI_DIR}#$(ls -di "$JOBAPI_DIR" | awk '{print $1}')"
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --volume ${JOBAPI_DIR}:${JOBAPI_DIR} --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${jfp} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir --env BUILDKITE_AGENT_JOB_API_SOCKET --env BUILDKITE_AGENT_JOB_API_TOKEN image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Creating persistent container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: reuses despite a changed Job API socket filename" {
+  JOBAPI_DIR="$(mktemp -d)"
+  # A later job's socket lives in the same dir under a different filename.
+  export BUILDKITE_AGENT_JOB_API_SOCKET="${JOBAPI_DIR}/4178-50521.sock"
+  export BUILDKITE_AGENT_JOB_API_TOKEN="tok2"
+  # The stored fingerprint (from the job that created the container) keys off
+  # the stable directory mount, so it matches this job's recomputed value.
+  local jfp="--init,--volume=${PWD}:/workdir#$(ls -di "$PWD" | awk '{print $1}'),--volume=${JOBAPI_DIR}:${JOBAPI_DIR}#$(ls -di "$JOBAPI_DIR" | awk '{print $1}')"
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${jfp}" \
+    "exec -t -i --workdir /workdir --env BUILDKITE_AGENT_JOB_API_SOCKET --env BUILDKITE_AGENT_JOB_API_TOKEN image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Reusing existing container"
+  refute_output --partial "fingerprint changed"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: non-reuse path mounts the single Job API socket file" {
+  export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER=false
+  JOBAPI_DIR="$(mktemp -d)"
+  export BUILDKITE_AGENT_JOB_API_SOCKET="${JOBAPI_DIR}/3760-27802.sock"
+  export BUILDKITE_AGENT_JOB_API_TOKEN="tok"
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''" \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --env BUILDKITE_AGENT_JOB_API_SOCKET --env BUILDKITE_AGENT_JOB_API_TOKEN --volume ${JOBAPI_DIR}/3760-27802.sock:${JOBAPI_DIR}/3760-27802.sock --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
   assert_output --partial "ran command in docker"
 
   unstub docker

--- a/tests/reuse-container.bats
+++ b/tests/reuse-container.bats
@@ -14,12 +14,28 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_RUN_LABELS="false"
   export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER=true
   export BUILDKITE_AGENT_NAME="builder-3"
+
+  # Redirect the host tainted-marker scratch base away from the real /var/tmp so
+  # tests never write outside their sandbox.
+  TAINTED_BASE="$(mktemp -d)"
+  export BUILDKITE_PLUGIN_DOCKER_REUSE_TAINTED_BASE="${TAINTED_BASE}"
+
+  # The create-flag fingerprint the plugin will compute for the default config:
+  # frozen flags in build order, joined with "," (per-exec flags -t/-i/--workdir,
+  # the job-id --label, and the tainted mount are excluded). For this setup that
+  # is "--init" plus the inode-annotated checkout volume.
+  FP="--init,--volume=${PWD}:/workdir#$(ls -di "$PWD" | awk '{print $1}')"
+}
+
+teardown() {
+  rm -rf "${TAINTED_BASE}"
 }
 
 @test "Reuse container: creates new container when none exists" {
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
-    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -31,11 +47,13 @@ setup() {
   unstub docker
 }
 
-@test "Reuse container: exec into existing container with matching image digest" {
+@test "Reuse container: exec into existing container with matching image digest and fingerprint" {
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
     "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${FP}" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -47,13 +65,105 @@ setup() {
   unstub docker
 }
 
+@test "Reuse container: recreates container when create-flag fingerprint changes" {
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo some-old-fingerprint" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Create-flag fingerprint changed"
+  assert_output --partial "Creating persistent container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: recreates container when fingerprint label is missing" {
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ''" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Create-flag fingerprint changed"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: recreates when a create-time flag (tmpfs) changes" {
+  export BUILDKITE_PLUGIN_DOCKER_TMPFS_0="/home/zoox/.cache:mode=777"
+  TMPFS_FP="--init,--tmpfs,/home/zoox/.cache:mode=777,--volume=${PWD}:/workdir#$(ls -di "$PWD" | awk '{print $1}')"
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${FP}" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -d --name image-tag-3 -t -i --init --tmpfs /home/zoox/.cache:mode=777 --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${TMPFS_FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Create-flag fingerprint changed"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: discards tainted container and recreates" {
+  mkdir -p "${TAINTED_BASE}/image-tag-3"
+  echo "out of memory" > "${TAINTED_BASE}/image-tag-3/tainted"
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${FP}" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "is tainted"
+  assert_output --partial "reason: out of memory"
+  assert_output --partial "ran command in docker"
+  # The marker is cleared and the dir re-created (and writable) on recreation.
+  [ ! -f "${TAINTED_BASE}/image-tag-3/tainted" ]
+  [ -d "${TAINTED_BASE}/image-tag-3" ]
+
+  unstub docker
+}
+
 @test "Reuse container: replaces container on image digest mismatch" {
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
     "inspect --format '{{.Image}}' image-tag-3 : echo sha256:olddigest" \
     "image inspect --format '{{.Id}}' image:tag : echo sha256:newdigest" \
     "rm -f image-tag-3 : echo removed" \
-    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -69,9 +179,10 @@ setup() {
 
 @test "Reuse container: removes and recreates stopped container" {
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : echo false" \
     "rm -f image-tag-3 : echo removed" \
-    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -83,12 +194,50 @@ setup() {
   unstub docker
 }
 
+@test "Reuse container: discards mismatched persistent container, keeps desired" {
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : printf '%s\n' image-other-3 image-tag-3" \
+    "rm -f image-other-3 : echo removed" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${FP}" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Discarding persistent container image-other-3"
+  assert_output --partial "Reusing existing container"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: non-reuse job discards leftover persistent container" {
+  export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER=false
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "rm -f image-tag-3 : echo removed" \
+    "run -t -i --rm --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 image:tag /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Discarding persistent container image-tag-3"
+  assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
 @test "Reuse container: uses custom container name" {
   export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER_NAME="my-custom-container"
 
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''" \
     "container inspect --format '{{.State.Running}}' my-custom-container : exit 1" \
-    "run -d --name my-custom-container -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name my-custom-container -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/my-custom-container:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir my-custom-container /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -100,12 +249,26 @@ setup() {
   unstub docker
 }
 
-@test "Reuse container: omits spawn index when agent name has no numeric suffix" {
+@test "Reuse container: rejects path-traversal custom container name" {
+  export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER_NAME="../evil"
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "Invalid reuse container name"
+
+  unstub docker
+}
+
+@test "Reuse container: omits spawn index and cleanup when agent name has no numeric suffix" {
   export BUILDKITE_AGENT_NAME="solo-agent"
 
   stub docker \
     "container inspect --format '{{.State.Running}}' image-tag : exit 1" \
-    "run -d --name image-tag -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name image-tag -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -123,9 +286,11 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=OTHER=thing
 
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
     "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${FP}" \
     "exec -t -i --workdir /workdir --env MY_TAG=value --env OTHER=thing image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -141,8 +306,9 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_ENVIRONMENT_1=SECRET=supersecret
 
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
-    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir --env MY_TAG=value --env SECRET=supersecret image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -164,8 +330,9 @@ setup() {
 
 @test "Reuse container: no --rm flag in docker run args" {
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo ''" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : exit 1" \
-    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
   run "$PWD"/hooks/command
@@ -178,9 +345,11 @@ setup() {
 
 @test "Reuse container: propagates exec exit code on failure" {
   stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
     "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo ${FP}" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : exit 42"
 
   run "$PWD"/hooks/command

--- a/tests/reuse-container.bats
+++ b/tests/reuse-container.bats
@@ -15,6 +15,9 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_REUSE_CONTAINER=true
   export BUILDKITE_AGENT_NAME="builder-3"
 
+  # Keep the removal verify/retry loop instant in tests (no real sleeping).
+  export REUSE_RM_VERIFY_SLEEP=0
+
   # Redirect the host tainted-marker scratch base away from the real /var/tmp so
   # tests never write outside their sandbox.
   TAINTED_BASE="$(mktemp -d)"
@@ -76,6 +79,7 @@ teardown() {
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
     "inspect --format \* image-tag-3 : echo some-old-fingerprint" \
     "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
     "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
@@ -97,6 +101,7 @@ teardown() {
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
     "inspect --format \* image-tag-3 : echo ''" \
     "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
     "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
@@ -120,6 +125,7 @@ teardown() {
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
     "inspect --format \* image-tag-3 : echo ${FP}" \
     "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
     "run -d --name image-tag-3 -t -i --init --tmpfs /home/zoox/.cache:mode=777 --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${TMPFS_FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
@@ -128,6 +134,65 @@ teardown() {
   assert_success
   assert_output --partial "Create-flag fingerprint changed"
   assert_output --partial "ran command in docker"
+
+  unstub docker
+}
+
+@test "Reuse container: retries removal until the name is freed, then recreates" {
+  # docker rm -f "succeeds" but the container lingers ("Removal In Progress");
+  # the verify loop re-checks and re-removes until the name is actually free,
+  # then the recreate proceeds normally (no cleanup-failure, no name conflict).
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo some-old-fingerprint" \
+    "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : echo still-here" \
+    "container inspect image-tag-3 : echo still-here" \
+    "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
+    "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
+    "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "Create-flag fingerprint changed"
+  assert_output --partial "Creating persistent container"
+  assert_output --partial "ran command in docker"
+  refute_output --partial "REUSE_CONTAINER_CLEANUP_FAILED"
+
+  unstub docker
+}
+
+@test "Reuse container: fails with known signature when the container cannot be removed" {
+  # docker rm -f fails and the container never leaves; after the attempt budget
+  # is exhausted the job aborts with the greppable REUSE_CONTAINER_CLEANUP_FAILED
+  # signature instead of blindly running into a cryptic name conflict.
+  export REUSE_RM_VERIFY_ATTEMPTS=2
+
+  stub docker \
+    "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
+    "container inspect --format '{{.State.Running}}' image-tag-3 : echo true" \
+    "inspect --format '{{.Image}}' image-tag-3 : echo sha256:abc123" \
+    "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
+    "inspect --format \* image-tag-3 : echo some-old-fingerprint" \
+    "rm -f image-tag-3 : echo 'Error response from daemon: device or resource busy' >&2; exit 1" \
+    "container inspect image-tag-3 : echo still-here" \
+    "container inspect image-tag-3 : echo still-here" \
+    "rm -f image-tag-3 : exit 1" \
+    "container inspect image-tag-3 : echo still-here" \
+    "rm -f image-tag-3 : exit 1" \
+    "container inspect image-tag-3 : echo still-here" \
+    "ps -a --filter name=^/image-tag-3\$ --format '      {{.ID}} {{.Image}} {{.Status}} {{.Names}}' : echo 'deadbeef image:tag Dead image-tag-3'"
+
+  run "$PWD"/hooks/command
+
+  assert_failure
+  assert_output --partial "REUSE_CONTAINER_CLEANUP_FAILED"
+  refute_output --partial "ran command in docker"
 
   unstub docker
 }
@@ -209,6 +274,7 @@ teardown() {
     "image inspect --format '{{.Id}}' image:tag : echo sha256:abc123" \
     "inspect --format \* image-tag-3 : echo ${FP}" \
     "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
     "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
@@ -232,6 +298,7 @@ teardown() {
     "inspect --format '{{.Image}}' image-tag-3 : echo sha256:olddigest" \
     "image inspect --format '{{.Id}}' image:tag : echo sha256:newdigest" \
     "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
     "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 
@@ -251,6 +318,7 @@ teardown() {
     "ps -a --filter label=com.buildkite.docker-plugin.reuse=true --filter label=com.buildkite.docker-plugin.spawn-slot=3 --format '{{.Names}}' : echo image-tag-3" \
     "container inspect --format '{{.State.Running}}' image-tag-3 : echo false" \
     "rm -f image-tag-3 : echo removed" \
+    "container inspect image-tag-3 : exit 1" \
     "run -d --name image-tag-3 -t -i --init --volume $PWD:/workdir --workdir /workdir --label com.buildkite.job-id=1-2-3-4 --label com.buildkite.docker-plugin.reuse=true --label com.buildkite.docker-plugin.spawn-slot=3 --label com.buildkite.docker-plugin.fingerprint=${FP} --volume ${TAINTED_BASE}/image-tag-3:/var/run/buildkite-docker-reuse --entrypoint '' image:tag sleep infinity : echo abc123" \
     "exec -t -i --workdir /workdir image-tag-3 /bin/sh -e -c 'pwd' : echo ran command in docker"
 


### PR DESCRIPTION
Add a persistent container feature. When `reuse-container: true`
is set, the plugin keeps a container alive across job steps
instead of creating and destroying one each time.
Key behaviors:
- Derives a stable container name from the image name and agent
  spawn index (or uses an explicit `reuse-container-name` override).
- On each job, checks for an existing running container: if the
  image digest matches, attaches via `docker exec`; if the digest
  differs, prints a warning banner, removes the stale container,
  and creates a fresh one.
- New containers are started detached (`docker run -d ... sleep
  infinity`) with `--rm` suppressed, then the job command runs via
  `docker exec`.
- Environment variables are stripped from the creation `docker run`
  and injected per-exec only, preventing secrets from leaking
  between jobs that share the container.
- The `pre-exit` hook skips container cleanup when reuse-container
  is enabled so the container persists for subsequent jobs.
Files changed:
- plugin.yml: new `reuse-container` and `reuse-container-name` opts
- lib/shared.bash: `get_reuse_container_name`,
  `get_container_image_id`, `get_image_id` helpers
- commands/run.sh: reuse-container branch with exec-arg extraction,
  digest validation, and detached container creation
- hooks/pre-exit: skip cleanup when reuse-container is set
- tests/reuse-container.bats: 11 bats tests covering creation,
  reuse, digest mismatch, stopped container, custom name, spawn
  index, env passthrough, env stripping, pre-exit, --rm absence,
  and exit code propagation