### PR TITLE
Skip Job API socket mount on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,12 @@ Default: `false`
 
 **Important:** enabling this option will share the `BUILDKITE_AGENT_TOKEN` and `BUILDKITE_AGENT_JOB_API_TOKEN` environment variables (and other related ones) with the container if present.
 
+#### Job API
+
+When the agent exposes the [Job API](https://buildkite.com/docs/agent/v3/cli-redact) (i.e. `BUILDKITE_AGENT_JOB_API_SOCKET` is present), the plugin automatically mounts its Unix domain socket into the container and shares the related environment variables, so that tools running inside the container can talk to the agent. This happens regardless of the `mount-buildkite-agent` option.
+
+**Note:** this is skipped on Windows agents. The Job API socket is a Unix domain socket, which cannot be bind-mounted into [Windows containers](https://learn.microsoft.com/en-us/virtualization/windowscontainers/about/), so it is not available inside the container on Windows.
+
 ### `mount-ssh-agent` (optional, boolean or string)
 
 Whether to mount the ssh-agent socket (at `/ssh-agent`) from the host agent machine into the container or not. Instead of just `true` or `false`, you can specify absolute path in the container for the home directory of the user used to run on which the agent's `.ssh/known_hosts` will be mounted (by default, `/root`).

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -246,11 +246,20 @@ if [[ -n "${BUILDKITE_AGENT_BINARY_PATH:-}" ]] ; then
 fi
 
 if [[ -n "${BUILDKITE_AGENT_JOB_API_SOCKET:-}" ]] ; then
-  args+=(
-    "--env" "BUILDKITE_AGENT_JOB_API_SOCKET"
-    "--env" "BUILDKITE_AGENT_JOB_API_TOKEN"
-    "--volume" "$BUILDKITE_AGENT_JOB_API_SOCKET:$BUILDKITE_AGENT_JOB_API_SOCKET"
-  )
+  # The Job API socket is a Unix domain socket and cannot be bind-mounted into
+  # Windows containers (Docker requires the bind source to be a directory),
+  # so we skip mounting it on Windows. See issue #305.
+  if is_windows; then
+    echo "~~~ :warning: Skipping Job API socket mount on Windows"
+    echo "The Buildkite Agent Job API is not supported inside Windows containers, so"
+    echo "BUILDKITE_AGENT_JOB_API_SOCKET will not be mounted into the container."
+  else
+    args+=(
+      "--env" "BUILDKITE_AGENT_JOB_API_SOCKET"
+      "--env" "BUILDKITE_AGENT_JOB_API_TOKEN"
+      "--volume" "$BUILDKITE_AGENT_JOB_API_SOCKET:$BUILDKITE_AGENT_JOB_API_SOCKET"
+    )
+  fi
 fi
 
 # Parse extra env vars and add them to the docker args

--- a/tests/windows.bats
+++ b/tests/windows.bats
@@ -53,6 +53,30 @@ setup() {
   unstub cmd.exe
 }
 
+@test "Does not mount Job API socket on Windows" {
+  export OSTYPE="win"
+  export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=false
+  export BUILDKITE_COMMAND="pwd"
+  export BUILDKITE_AGENT_JOB_API_SOCKET='C:\buildkite-agent\.buildkite-agent\sockets\job-api\3568-11799.sock'
+  export BUILDKITE_AGENT_JOB_API_TOKEN="sometoken"
+
+  stub cmd.exe \
+    "//C $'echo %CD%' : echo WIN_PATH"
+
+  stub docker \
+    "run -i --rm --volume WIN_PATH:C:/workdir --workdir C:/workdir --label com.buildkite.job-id=1-2-3-4 image:tag CMD.EXE /c 'pwd' : echo ran command in docker"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in docker"
+  assert_output --partial "Skipping Job API socket mount on Windows"
+  refute_output --partial "job-api"
+
+  unstub docker
+  unstub cmd.exe
+}
+
 @test "Run with double backslash Windows agent path" {
   export OSTYPE="win"
   export BUILDKITE_PLUGIN_DOCKER_MOUNT_BUILDKITE_AGENT=true


### PR DESCRIPTION
## Description

On Windows, the Job API socket is a Unix domain, which can't be bind-mounted.

## Changes

- adds a test for skipping the bind-mount for Windows
- implements a skip for bind-mounting the job api socket on windows
- adds some information to the readme

## Context

Fixes https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/305
